### PR TITLE
Expo 243

### DIFF
--- a/src/account/account.controller.ts
+++ b/src/account/account.controller.ts
@@ -17,8 +17,11 @@ import {
   UpdateGlobalFilterResponseDto,
   updateGlobalFilterResponseSchema,
 } from '@/account/dto/update-global-filter.dto';
+import {
+  Account,
+  AccountWithoutPassword,
+} from '@/auth/decorators/account.decorator';
 import { Roles } from '@/auth/decorators/rol.decorator';
-import { AccountWithoutPassword, User } from '@/auth/decorators/user.decorator';
 import { JwtGuard } from '@/auth/guards/jwt.guard';
 import { RoleGuard } from '@/auth/guards/role.guard';
 import { translate } from '@/i18n/translate';
@@ -51,7 +54,7 @@ export class AccountController {
   })
   async updateGlobalFilter(
     @Body() body: UpdateGlobalFilterDto,
-    @User() user: AccountWithoutPassword,
+    @Account() user: AccountWithoutPassword,
   ): Promise<z.infer<typeof updateGlobalFilterResponseSchema>> {
     return await this.accountService.updateGlobalFilter(user.id, body);
   }
@@ -64,7 +67,7 @@ export class AccountController {
     type: GetGlobalFilterResponseDto,
   })
   async getGlobalFilter(
-    @User() user: AccountWithoutPassword,
+    @Account() user: AccountWithoutPassword,
   ): Promise<z.infer<typeof getGlobalFilterResponseSchema>> {
     return await this.accountService.getGlobalFilter(user.id);
   }
@@ -77,7 +80,7 @@ export class AccountController {
     type: GetMeResponseDto,
   })
   async getMe(
-    @User() user: AccountWithoutPassword,
+    @Account() user: AccountWithoutPassword,
   ): Promise<z.infer<typeof getMeResponseSchema>> {
     const myGlobalFilter = await this.accountService.getGlobalFilter(user.id);
     const tags = await this.accountService.getTags(user.id);

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,6 +2,7 @@ import { AccountModule } from '@/account/account.module';
 import { AppController } from '@/app.controller';
 import { AppService } from '@/app.service';
 import { AuthModule } from '@/auth/auth.module';
+import { CommentModule } from '@/comment/comment.module';
 import { ZodValidationPipe } from '@/filters/zod.pipe';
 import { PrismaService } from '@/prisma/prisma.service';
 import { TagGroupModule } from '@/tag-group/tag-group.module';
@@ -17,6 +18,7 @@ import { APP_PIPE } from '@nestjs/core';
     TagModule,
     AccountModule,
     TagGroupModule,
+    CommentModule,
   ],
   providers: [
     {

--- a/src/auth/decorators/account.decorator.ts
+++ b/src/auth/decorators/account.decorator.ts
@@ -8,11 +8,11 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
-import { Account } from '~/types/prisma-schema';
+import { type Account as AccountType } from '~/types/prisma-schema';
 
-export type AccountWithoutPassword = Omit<Account, 'password'>;
+export type AccountWithoutPassword = Omit<AccountType, 'password'>;
 
-export const User = createParamDecorator(
+export const Account = createParamDecorator(
   async (data: unknown, context: ExecutionContext) => {
     const request = context.switchToHttp().getRequest();
     const jwtService = new JwtService({ secret: process.env.JWT_SECRET });

--- a/src/comment/comment.controller.ts
+++ b/src/comment/comment.controller.ts
@@ -1,0 +1,119 @@
+import {
+  Account,
+  AccountWithoutPassword,
+} from '@/auth/decorators/account.decorator';
+import { Roles } from '@/auth/decorators/rol.decorator';
+import { JwtGuard } from '@/auth/guards/jwt.guard';
+import { RoleGuard } from '@/auth/guards/role.guard';
+import { CommentService } from '@/comment/comment.service';
+import {
+  CreateCommentDto,
+  CreateCommentResponseDto,
+  createCommentResponseSchema,
+} from '@/comment/dto/create-comment.dto';
+import {
+  GetByProfileCommentResponseDto,
+  getByProfileCommentResponseSchema,
+} from '@/comment/dto/get-by-profile-comment.dto';
+import {
+  ToggleSolveCommentResponseDto,
+  toggleSolveCommentResponseSchema,
+} from '@/comment/dto/toggle-solve-comment.dto';
+import { translate } from '@/i18n/translate';
+import { ErrorDto } from '@/shared/errors/errorType';
+import { ExistingRecord } from '@/shared/validation/checkExistingRecord';
+import {
+  Body,
+  ConflictException,
+  Controller,
+  Get,
+  Param,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiConflictResponse,
+  ApiCreatedResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+} from '@nestjs/swagger';
+import z from 'zod';
+import { Comment, Profile, Role } from '~/types';
+
+@Roles(Role.ADMIN, Role.USER)
+@UseGuards(JwtGuard, RoleGuard)
+@Controller('comment')
+export class CommentController {
+  constructor(private readonly commentService: CommentService) {}
+
+  @ApiNotFoundResponse({
+    description: translate('route.comment.create.not-found'),
+    type: ErrorDto,
+  })
+  @ApiCreatedResponse({
+    description: translate('route.comment.create.success'),
+    type: CreateCommentResponseDto,
+  })
+  @Post('/create')
+  async createComment(
+    @Body() createCommentDto: CreateCommentDto,
+    @Account() account: AccountWithoutPassword,
+  ): Promise<z.infer<typeof createCommentResponseSchema>> {
+    // TODO: Add validation for the profileId
+    // throw new NotFoundException([
+    //   translate('prisma.not-found', {
+    //     field: 'id',
+    //     model: translate('prisma.model.profile'),
+    //     value: createCommentDto.profileId,
+    //   }),
+    // ]);
+
+    return await this.commentService.createComment(
+      createCommentDto,
+      account.id,
+    );
+  }
+
+  @ApiNotFoundResponse({
+    description: translate('route.comment.get-by-profile.not-found'),
+    type: ErrorDto,
+  })
+  @ApiOkResponse({
+    description: translate('route.comment.get-by-profile.success'),
+    type: GetByProfileCommentResponseDto,
+  })
+  @Get('/get-by-profile/:id')
+  async getCommentsByProfileId(
+    @Param('id', new ExistingRecord('profile')) profileId: Profile['id'],
+  ): Promise<z.infer<typeof getByProfileCommentResponseSchema>> {
+    return await this.commentService.getCommentsByProfileId(profileId);
+  }
+
+  @ApiConflictResponse({
+    description: translate('route.comment.toggle-solve.conflict'),
+    type: ErrorDto,
+  })
+  @ApiOkResponse({
+    description: translate('route.comment.toggle-solve.success'),
+    type: ToggleSolveCommentResponseDto,
+  })
+  @ApiNotFoundResponse({
+    description: translate('route.comment.toggle-solve.not-found'),
+    type: ErrorDto,
+  })
+  @Patch('/toggle-solve/:id')
+  async toggleSolveComment(
+    @Param('id', new ExistingRecord('comment')) id: Comment['id'],
+    @Account() account: AccountWithoutPassword,
+  ): Promise<z.infer<typeof toggleSolveCommentResponseSchema>> {
+    const isSolvable = await this.commentService.isCommentSolvable(id);
+    if (!isSolvable) {
+      throw new ConflictException([
+        translate('route.comment.toggle-solve.conflict'),
+      ]);
+    }
+
+    return await this.commentService.solveComment(id, account.id);
+  }
+}

--- a/src/comment/comment.module.ts
+++ b/src/comment/comment.module.ts
@@ -1,0 +1,12 @@
+import { AccountService } from '@/account/account.service';
+import { PrismaService } from '@/prisma/prisma.service';
+import { Module } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { CommentController } from './comment.controller';
+import { CommentService } from './comment.service';
+
+@Module({
+  providers: [CommentService, PrismaService, JwtService, AccountService],
+  controllers: [CommentController],
+})
+export class CommentModule {}

--- a/src/comment/comment.service.ts
+++ b/src/comment/comment.service.ts
@@ -1,0 +1,98 @@
+import { CreateCommentDto } from '@/comment/dto/create-comment.dto';
+import { getByProfileCommentResponseSchema } from '@/comment/dto/get-by-profile-comment.dto';
+import { PrismaService } from '@/prisma/prisma.service';
+import { Injectable } from '@nestjs/common';
+import z from 'zod';
+import { Account, Comment } from '~/types';
+
+@Injectable()
+export class CommentService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async createComment(
+    dto: CreateCommentDto,
+    accountId: Account['id'],
+  ): Promise<Comment> {
+    return await this.prisma.comment.create({
+      data: {
+        content: dto.content,
+        isSolvable: dto.isSolvable,
+        profileId: dto.profileId,
+        createdBy: accountId,
+      },
+    });
+  }
+
+  async getCommentsByProfileId(
+    profileId: Comment['profileId'],
+  ): Promise<z.infer<typeof getByProfileCommentResponseSchema>> {
+    const comments = await this.prisma.comment.findMany({
+      where: {
+        profileId: profileId,
+      },
+      include: {
+        account: {
+          select: {
+            username: true,
+          },
+        },
+      },
+      orderBy: [
+        {
+          created_at: 'desc',
+        },
+        {
+          id: 'desc',
+        },
+      ],
+    });
+
+    return {
+      comments,
+    };
+  }
+
+  private async isCommentSolved(
+    commentId: Comment['id'],
+  ): Promise<Comment['isSolved']> {
+    return (await this.prisma.comment.findUnique({
+      where: {
+        id: commentId,
+      },
+      select: {
+        isSolved: true,
+      },
+    }))!.isSolved;
+  }
+
+  async solveComment(
+    commentId: Comment['id'],
+    accountId: Account['id'],
+  ): Promise<Comment> {
+    const isSolved = await this.isCommentSolved(commentId);
+
+    return await this.prisma.comment.update({
+      where: {
+        id: commentId,
+      },
+      data: {
+        isSolved: !isSolved,
+        solvedAt: !isSolved ? new Date() : null,
+        solvedById: !isSolved ? accountId : null,
+      },
+    });
+  }
+
+  async isCommentSolvable(
+    commentId: Comment['id'],
+  ): Promise<Comment['isSolvable']> {
+    return (await this.prisma.comment.findUnique({
+      where: {
+        id: commentId,
+      },
+      select: {
+        isSolvable: true,
+      },
+    }))!.isSolvable;
+  }
+}

--- a/src/comment/dto/comment.dto.ts
+++ b/src/comment/dto/comment.dto.ts
@@ -10,11 +10,17 @@ export const commentSchema = z.object({
   content: z.string().min(1, {
     message: translate('model.comment.content.min'),
   }),
-  createdBy: accountSchema.shape.id,
 
-  isSolvable: z.boolean().default(false),
+  createdBy: accountSchema.shape.id,
+  profileId: accountSchema.shape.id,
+
+  isSolvable: z
+    .boolean({
+      required_error: translate('model.comment.isSolvable.required'),
+    })
+    .default(false),
   isSolved: z.boolean().default(false),
-  solvedAt: z.date().optional(),
+  solvedAt: z.date().nullable(),
   solvedBy: accountSchema.shape.id.optional(),
 
   created_at: z.date(),

--- a/src/comment/dto/create-comment.dto.ts
+++ b/src/comment/dto/create-comment.dto.ts
@@ -1,0 +1,18 @@
+import { commentSchema } from '@/comment/dto/comment.dto';
+import { createZodDtoWithoutDate } from '@/shared/dto-modification/create-zod-dto-without-date';
+
+export const createCommentSchema = commentSchema.pick({
+  content: true,
+  profileId: true,
+  isSolvable: true,
+});
+
+export class CreateCommentDto extends createZodDtoWithoutDate(
+  createCommentSchema,
+) {}
+
+export const createCommentResponseSchema = commentSchema;
+
+export class CreateCommentResponseDto extends createZodDtoWithoutDate(
+  createCommentResponseSchema,
+) {}

--- a/src/comment/dto/get-by-profile-comment.dto.ts
+++ b/src/comment/dto/get-by-profile-comment.dto.ts
@@ -1,0 +1,20 @@
+import { accountSchema } from '@/account/dto/account.dto';
+import { commentSchema } from '@/comment/dto/comment.dto';
+import { createZodDtoWithoutDate } from '@/shared/dto-modification/create-zod-dto-without-date';
+import z from 'zod';
+
+export const getByProfileCommentResponseSchema = z.object({
+  comments: z.array(
+    commentSchema.merge(
+      z.object({
+        account: accountSchema.pick({
+          username: true,
+        }),
+      }),
+    ),
+  ),
+});
+
+export class GetByProfileCommentResponseDto extends createZodDtoWithoutDate(
+  getByProfileCommentResponseSchema,
+) {}

--- a/src/comment/dto/toggle-solve-comment.dto.ts
+++ b/src/comment/dto/toggle-solve-comment.dto.ts
@@ -1,0 +1,8 @@
+import { commentSchema } from '@/comment/dto/comment.dto';
+import { createZodDtoWithoutDate } from '@/shared/dto-modification/create-zod-dto-without-date';
+
+export const toggleSolveCommentResponseSchema = commentSchema;
+
+export class ToggleSolveCommentResponseDto extends createZodDtoWithoutDate(
+  toggleSolveCommentResponseSchema,
+) {}

--- a/src/comment/exports.ts
+++ b/src/comment/exports.ts
@@ -1,1 +1,4 @@
 export * from './dto/comment.dto';
+export * from './dto/create-comment.dto';
+export * from './dto/get-by-profile-comment.dto';
+export * from './dto/toggle-solve-comment.dto';

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -23,6 +23,9 @@ export default {
       content: {
         min: 'El contenido debe tener al menos 1 caracter',
       },
+      isSolvable: {
+        required: 'No se indica si el comentario es resoluble',
+      },
     },
     account: {
       id: {
@@ -179,6 +182,21 @@ export default {
       delete: {
         success: 'Grupo de etiquetas eliminado',
         'not-found': 'Grupo de etiquetas no encontrado',
+      },
+    },
+    comment: {
+      create: {
+        success: 'Comentario creado con éxito',
+        'not-found': 'Perfil no encontrado',
+      },
+      'get-by-profile': {
+        success: 'Comentarios obtenidos',
+        'not-found': 'Perfil no encontrado',
+      },
+      'toggle-solve': {
+        success: 'Cambio de estado en la resolución del comentario',
+        'not-found': 'Comentario no encontrado',
+        conflict: 'El comentario no es resoluble',
       },
     },
   },

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -318,6 +318,69 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorDto"
+  /comment/create:
+    post:
+      operationId: "CommentController_createComment"
+      parameters: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateCommentDto"
+      responses:
+        201:
+          description: "Comentario creado con éxito"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateCommentResponseDto"
+        404:
+          description: "Perfil no encontrado"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorDto"
+  /comment/get-by-profile/{id}:
+    get:
+      operationId: "CommentController_getCommentsByProfileId"
+      parameters: []
+      responses:
+        200:
+          description: "Comentarios obtenidos"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GetByProfileCommentResponseDto"
+        404:
+          description: "Perfil no encontrado"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorDto"
+  /comment/toggle-solve/{id}:
+    patch:
+      operationId: "CommentController_toggleSolveComment"
+      parameters: []
+      responses:
+        200:
+          description: "Cambio de estado en la resolución del comentario"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToggleSolveCommentResponseDto"
+        404:
+          description: "Comentario no encontrado"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorDto"
+        409:
+          description: "El comentario no es resoluble"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorDto"
 info:
   title: "Expo Backend"
   description: "Backend de las aplicaciones de Expo"
@@ -1327,5 +1390,168 @@ components:
         - "name"
         - "color"
         - "isExclusive"
+        - "created_at"
+        - "updated_at"
+    CreateCommentDto:
+      type: "object"
+      properties:
+        content:
+          type: "string"
+          minLength: 1
+        profileId:
+          type: "string"
+          format: "uuid"
+        isSolvable:
+          default: false
+          type: "boolean"
+      required:
+        - "content"
+        - "profileId"
+        - "isSolvable"
+    CreateCommentResponseDto:
+      type: "object"
+      properties:
+        id:
+          type: "string"
+          format: "uuid"
+        content:
+          type: "string"
+          minLength: 1
+        createdBy:
+          type: "string"
+          format: "uuid"
+        profileId:
+          type: "string"
+          format: "uuid"
+        isSolvable:
+          default: false
+          type: "boolean"
+        isSolved:
+          default: false
+          type: "boolean"
+        solvedAt:
+          type: "string"
+          format: "date-time"
+          nullable: true
+        solvedBy:
+          type: "string"
+          format: "uuid"
+        created_at:
+          type: "string"
+          format: "date-time"
+        updated_at:
+          type: "string"
+          format: "date-time"
+      required:
+        - "id"
+        - "content"
+        - "createdBy"
+        - "profileId"
+        - "isSolvable"
+        - "isSolved"
+        - "solvedAt"
+        - "solvedBy"
+        - "created_at"
+        - "updated_at"
+    GetByProfileCommentResponseDto:
+      type: "object"
+      properties:
+        comments:
+          type: "array"
+          items:
+            type: "object"
+            properties:
+              id:
+                type: "string"
+                format: "uuid"
+              content:
+                type: "string"
+                minLength: 1
+              createdBy:
+                type: "string"
+                format: "uuid"
+              profileId:
+                type: "string"
+                format: "uuid"
+              isSolvable:
+                default: false
+                type: "boolean"
+              isSolved:
+                default: false
+                type: "boolean"
+              solvedAt:
+                type: "string"
+                format: "date-time"
+                nullable: true
+              solvedBy:
+                type: "string"
+                format: "uuid"
+              created_at:
+                type: "string"
+                format: "date-time"
+              updated_at:
+                type: "string"
+                format: "date-time"
+              account:
+                type: "object"
+                properties:
+                  username:
+                    type: "string"
+                required:
+                  - "username"
+            required:
+              - "id"
+              - "content"
+              - "createdBy"
+              - "profileId"
+              - "solvedAt"
+              - "created_at"
+              - "updated_at"
+              - "account"
+      required:
+        - "comments"
+    ToggleSolveCommentResponseDto:
+      type: "object"
+      properties:
+        id:
+          type: "string"
+          format: "uuid"
+        content:
+          type: "string"
+          minLength: 1
+        createdBy:
+          type: "string"
+          format: "uuid"
+        profileId:
+          type: "string"
+          format: "uuid"
+        isSolvable:
+          default: false
+          type: "boolean"
+        isSolved:
+          default: false
+          type: "boolean"
+        solvedAt:
+          type: "string"
+          format: "date-time"
+          nullable: true
+        solvedBy:
+          type: "string"
+          format: "uuid"
+        created_at:
+          type: "string"
+          format: "date-time"
+        updated_at:
+          type: "string"
+          format: "date-time"
+      required:
+        - "id"
+        - "content"
+        - "createdBy"
+        - "profileId"
+        - "isSolvable"
+        - "isSolved"
+        - "solvedAt"
+        - "solvedBy"
         - "created_at"
         - "updated_at"

--- a/types/schema.ts
+++ b/types/schema.ts
@@ -212,6 +212,54 @@ export interface paths {
     patch: operations['TagGroupController_update'];
     trace?: never;
   };
+  '/comment/create': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: operations['CommentController_createComment'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/comment/get-by-profile/{id}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: operations['CommentController_getCommentsByProfileId'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/comment/toggle-solve/{id}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch: operations['CommentController_toggleSolveComment'];
+    trace?: never;
+  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -598,6 +646,81 @@ export interface components {
       name: string;
       color: string;
       isExclusive: boolean;
+      /** Format: date-time */
+      created_at: string;
+      /** Format: date-time */
+      updated_at: string;
+    };
+    CreateCommentDto: {
+      content: string;
+      /** Format: uuid */
+      profileId: string;
+      /** @default false */
+      isSolvable: boolean;
+    };
+    CreateCommentResponseDto: {
+      /** Format: uuid */
+      id: string;
+      content: string;
+      /** Format: uuid */
+      createdBy: string;
+      /** Format: uuid */
+      profileId: string;
+      /** @default false */
+      isSolvable: boolean;
+      /** @default false */
+      isSolved: boolean;
+      /** Format: date-time */
+      solvedAt: string | null;
+      /** Format: uuid */
+      solvedBy: string;
+      /** Format: date-time */
+      created_at: string;
+      /** Format: date-time */
+      updated_at: string;
+    };
+    GetByProfileCommentResponseDto: {
+      comments: {
+        /** Format: uuid */
+        id: string;
+        content: string;
+        /** Format: uuid */
+        createdBy: string;
+        /** Format: uuid */
+        profileId: string;
+        /** @default false */
+        isSolvable: boolean;
+        /** @default false */
+        isSolved: boolean;
+        /** Format: date-time */
+        solvedAt: string | null;
+        /** Format: uuid */
+        solvedBy?: string;
+        /** Format: date-time */
+        created_at: string;
+        /** Format: date-time */
+        updated_at: string;
+        account: {
+          username: string;
+        };
+      }[];
+    };
+    ToggleSolveCommentResponseDto: {
+      /** Format: uuid */
+      id: string;
+      content: string;
+      /** Format: uuid */
+      createdBy: string;
+      /** Format: uuid */
+      profileId: string;
+      /** @default false */
+      isSolvable: boolean;
+      /** @default false */
+      isSolved: boolean;
+      /** Format: date-time */
+      solvedAt: string | null;
+      /** Format: uuid */
+      solvedBy: string;
       /** Format: date-time */
       created_at: string;
       /** Format: date-time */
@@ -1077,6 +1200,106 @@ export interface operations {
       };
       /** @description Grupo de etiquetas no encontrado */
       404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorDto'];
+        };
+      };
+    };
+  };
+  CommentController_createComment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['CreateCommentDto'];
+      };
+    };
+    responses: {
+      /** @description Comentario creado con éxito */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['CreateCommentResponseDto'];
+        };
+      };
+      /** @description Perfil no encontrado */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorDto'];
+        };
+      };
+    };
+  };
+  CommentController_getCommentsByProfileId: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Comentarios obtenidos */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['GetByProfileCommentResponseDto'];
+        };
+      };
+      /** @description Perfil no encontrado */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorDto'];
+        };
+      };
+    };
+  };
+  CommentController_toggleSolveComment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Cambio de estado en la resolución del comentario */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ToggleSolveCommentResponseDto'];
+        };
+      };
+      /** @description Comentario no encontrado */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorDto'];
+        };
+      };
+      /** @description El comentario no es resoluble */
+      409: {
         headers: {
           [name: string]: unknown;
         };


### PR DESCRIPTION
En este PR se implementó el router de Comentario (`/comment`) con las siguientes rutas:
- POST `/create`: Crear un comentario
- GET `/get-by-profile/{id}`: Obtener los comentarios de un perfil
- PATCH `/toggle-solve/{id}`: Alternar estado de resolución de un comentario

