### PR TITLE
Expo 309 migrar configuracion

### DIFF
--- a/src/csv/csv.controller.ts
+++ b/src/csv/csv.controller.ts
@@ -12,9 +12,9 @@ import { ErrorDto } from '@/shared/errors/errorType';
 import {
   Body,
   Controller,
-  Get,
   Header,
   InternalServerErrorException,
+  Post,
   Response,
   StreamableFile,
   UseGuards,
@@ -51,7 +51,7 @@ export class CsvController {
     description: translate('route.csv.download-profiles.error'),
   })
   @Header('Content-Type', 'text/csv')
-  @Get('/download-profiles')
+  @Post('/download-profiles')
   async downloadProfiles(
     @Body() dto: DownloadProfilesDto,
     @Account() account: AccountWithoutPassword,
@@ -92,7 +92,7 @@ export class CsvController {
     description: translate('route.csv.download-all-tables.unauthorized'),
   })
   @Header('Content-Type', 'application/zip')
-  @Get('download-all-tables')
+  @Post('download-all-tables')
   async downloadAllTables(
     @Body() dto: DownloadAllTablesDto,
     @Account() account: AccountWithoutPassword,

--- a/src/csv/csv.controller.ts
+++ b/src/csv/csv.controller.ts
@@ -100,22 +100,16 @@ export class CsvController {
   ): Promise<Buffer> {
     await this.accountService.checkPassword(account.id, dto.password);
 
-    try {
-      const zipData = await this.csvService.exportAllTables();
+    const zipData = await this.csvService.exportAllTables();
 
-      const timestamp = this.csvService.generateTimestamp();
-      const filename = `${timestamp}-todas_las_tablas.zip`;
+    const timestamp = this.csvService.generateTimestamp();
+    const filename = `${timestamp}-todas_las_tablas.zip`;
 
-      res.set({
-        type: 'application/zip',
-        'Content-Disposition': `attachment; filename=${filename}`,
-      });
-      res.send(zipData);
-      return zipData;
-    } catch (error) {
-      throw new InternalServerErrorException([
-        translate('route.csv.download-all-tables.error'),
-      ]);
-    }
+    res.set({
+      type: 'application/zip',
+      'Content-Disposition': `attachment; filename=${filename}`,
+    });
+    res.send(zipData);
+    return zipData;
   }
 }

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -2,6 +2,7 @@ export * from './account/exports';
 export * from './auth/exports';
 export * from './canned-response/exports';
 export * from './comment/exports';
+export * from './csv/exports';
 export * from './event-folder/exports';
 export * from './event/exports';
 export * from './location/exports';

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1106,7 +1106,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorDto"
   /csv/download-profiles:
-    get:
+    post:
       operationId: "CsvController_downloadProfiles"
       parameters: []
       requestBody:
@@ -1135,7 +1135,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/StreamableFile"
   /csv/download-all-tables:
-    get:
+    post:
       operationId: "CsvController_downloadAllTables"
       parameters: []
       requestBody:

--- a/types/prisma-schema/index.d.ts
+++ b/types/prisma-schema/index.d.ts
@@ -80,23 +80,6 @@ export namespace $Enums {
 
   export type Role = (typeof Role)[keyof typeof Role];
 
-  export const TagType: {
-    PROFILE: 'PROFILE';
-    EVENT: 'EVENT';
-    PARTICIPANT: 'PARTICIPANT';
-    NOT_IN_SYSTEM: 'NOT_IN_SYSTEM';
-  };
-
-  export type TagType = (typeof TagType)[keyof typeof TagType];
-
-  export const MessageState: {
-    SENT: 'SENT';
-    RECEIVED: 'RECEIVED';
-    SEEN: 'SEEN';
-  };
-
-  export type MessageState = (typeof MessageState)[keyof typeof MessageState];
-
   export const TemplateStatus: {
     APPROVED: 'APPROVED';
     PENDING: 'PENDING';
@@ -114,19 +97,28 @@ export namespace $Enums {
 
   export type TemplateCategory =
     (typeof TemplateCategory)[keyof typeof TemplateCategory];
+
+  export const TagType: {
+    PROFILE: 'PROFILE';
+    EVENT: 'EVENT';
+    PARTICIPANT: 'PARTICIPANT';
+    NOT_IN_SYSTEM: 'NOT_IN_SYSTEM';
+  };
+
+  export type TagType = (typeof TagType)[keyof typeof TagType];
+
+  export const MessageState: {
+    SENT: 'SENT';
+    RECEIVED: 'RECEIVED';
+    SEEN: 'SEEN';
+  };
+
+  export type MessageState = (typeof MessageState)[keyof typeof MessageState];
 }
 
 export type Role = $Enums.Role;
 
 export const Role: typeof $Enums.Role;
-
-export type TagType = $Enums.TagType;
-
-export const TagType: typeof $Enums.TagType;
-
-export type MessageState = $Enums.MessageState;
-
-export const MessageState: typeof $Enums.MessageState;
 
 export type TemplateStatus = $Enums.TemplateStatus;
 
@@ -135,6 +127,14 @@ export const TemplateStatus: typeof $Enums.TemplateStatus;
 export type TemplateCategory = $Enums.TemplateCategory;
 
 export const TemplateCategory: typeof $Enums.TemplateCategory;
+
+export type TagType = $Enums.TagType;
+
+export const TagType: typeof $Enums.TagType;
+
+export type MessageState = $Enums.MessageState;
+
+export const MessageState: typeof $Enums.MessageState;
 
 /**
  * ##  Prisma Client ʲˢ
@@ -290,7 +290,18 @@ export class PrismaClient<
     },
   ): $Utils.JsPromise<R>;
 
-  $extends: $Extensions.ExtendsHook<'extends', Prisma.TypeMapCb, ExtArgs>;
+  $extends: $Extensions.ExtendsHook<
+    'extends',
+    Prisma.TypeMapCb,
+    ExtArgs,
+    $Utils.Call<
+      Prisma.TypeMapCb,
+      {
+        extArgs: ExtArgs;
+      }
+    >,
+    ClientOptions
+  >;
 
   /**
    * `prisma.account`: Exposes CRUD operations for the **Account** model.
@@ -300,7 +311,7 @@ export class PrismaClient<
    * const accounts = await prisma.account.findMany()
    * ```
    */
-  get account(): Prisma.AccountDelegate<ExtArgs>;
+  get account(): Prisma.AccountDelegate<ExtArgs, ClientOptions>;
 
   /**
    * `prisma.profile`: Exposes CRUD operations for the **Profile** model.
@@ -310,7 +321,7 @@ export class PrismaClient<
    * const profiles = await prisma.profile.findMany()
    * ```
    */
-  get profile(): Prisma.ProfileDelegate<ExtArgs>;
+  get profile(): Prisma.ProfileDelegate<ExtArgs, ClientOptions>;
 
   /**
    * `prisma.location`: Exposes CRUD operations for the **Location** model.
@@ -320,7 +331,7 @@ export class PrismaClient<
    * const locations = await prisma.location.findMany()
    * ```
    */
-  get location(): Prisma.LocationDelegate<ExtArgs>;
+  get location(): Prisma.LocationDelegate<ExtArgs, ClientOptions>;
 
   /**
    * `prisma.comment`: Exposes CRUD operations for the **Comment** model.
@@ -330,7 +341,7 @@ export class PrismaClient<
    * const comments = await prisma.comment.findMany()
    * ```
    */
-  get comment(): Prisma.CommentDelegate<ExtArgs>;
+  get comment(): Prisma.CommentDelegate<ExtArgs, ClientOptions>;
 
   /**
    * `prisma.tag`: Exposes CRUD operations for the **Tag** model.
@@ -340,7 +351,7 @@ export class PrismaClient<
    * const tags = await prisma.tag.findMany()
    * ```
    */
-  get tag(): Prisma.TagDelegate<ExtArgs>;
+  get tag(): Prisma.TagDelegate<ExtArgs, ClientOptions>;
 
   /**
    * `prisma.tagGroup`: Exposes CRUD operations for the **TagGroup** model.
@@ -350,7 +361,7 @@ export class PrismaClient<
    * const tagGroups = await prisma.tagGroup.findMany()
    * ```
    */
-  get tagGroup(): Prisma.TagGroupDelegate<ExtArgs>;
+  get tagGroup(): Prisma.TagGroupDelegate<ExtArgs, ClientOptions>;
 
   /**
    * `prisma.event`: Exposes CRUD operations for the **Event** model.
@@ -360,7 +371,7 @@ export class PrismaClient<
    * const events = await prisma.event.findMany()
    * ```
    */
-  get event(): Prisma.EventDelegate<ExtArgs>;
+  get event(): Prisma.EventDelegate<ExtArgs, ClientOptions>;
 
   /**
    * `prisma.eventFolder`: Exposes CRUD operations for the **EventFolder** model.
@@ -370,7 +381,7 @@ export class PrismaClient<
    * const eventFolders = await prisma.eventFolder.findMany()
    * ```
    */
-  get eventFolder(): Prisma.EventFolderDelegate<ExtArgs>;
+  get eventFolder(): Prisma.EventFolderDelegate<ExtArgs, ClientOptions>;
 
   /**
    * `prisma.message`: Exposes CRUD operations for the **Message** model.
@@ -380,7 +391,7 @@ export class PrismaClient<
    * const messages = await prisma.message.findMany()
    * ```
    */
-  get message(): Prisma.MessageDelegate<ExtArgs>;
+  get message(): Prisma.MessageDelegate<ExtArgs, ClientOptions>;
 
   /**
    * `prisma.cannedResponse`: Exposes CRUD operations for the **CannedResponse** model.
@@ -390,7 +401,7 @@ export class PrismaClient<
    * const cannedResponses = await prisma.cannedResponse.findMany()
    * ```
    */
-  get cannedResponse(): Prisma.CannedResponseDelegate<ExtArgs>;
+  get cannedResponse(): Prisma.CannedResponseDelegate<ExtArgs, ClientOptions>;
 
   /**
    * `prisma.enums`: Exposes CRUD operations for the **Enums** model.
@@ -400,7 +411,7 @@ export class PrismaClient<
    * const enums = await prisma.enums.findMany()
    * ```
    */
-  get enums(): Prisma.EnumsDelegate<ExtArgs>;
+  get enums(): Prisma.EnumsDelegate<ExtArgs, ClientOptions>;
 }
 
 export namespace Prisma {
@@ -421,7 +432,6 @@ export namespace Prisma {
   export import PrismaClientRustPanicError = runtime.PrismaClientRustPanicError;
   export import PrismaClientInitializationError = runtime.PrismaClientInitializationError;
   export import PrismaClientValidationError = runtime.PrismaClientValidationError;
-  export import NotFoundError = runtime.NotFoundError;
 
   /**
    * Re-export of sql-template-tag
@@ -458,8 +468,8 @@ export namespace Prisma {
   export import Exact = $Public.Exact;
 
   /**
-   * Prisma Client JS version: 5.22.0
-   * Query Engine version: 605197351a3c8bdd595af2d2a9bc3025bca48ea2
+   * Prisma Client JS version: 6.3.1
+   * Query Engine version: acc0b9dd43eb689cbd20c9470515d719db10d0b0
    */
   export type PrismaVersion = {
     client: string;
@@ -962,6 +972,10 @@ export namespace Prisma {
             args: Prisma.AccountUpdateManyArgs<ExtArgs>;
             result: BatchPayload;
           };
+          updateManyAndReturn: {
+            args: Prisma.AccountUpdateManyAndReturnArgs<ExtArgs>;
+            result: $Utils.PayloadToResult<Prisma.$AccountPayload>[];
+          };
           upsert: {
             args: Prisma.AccountUpsertArgs<ExtArgs>;
             result: $Utils.PayloadToResult<Prisma.$AccountPayload>;
@@ -1031,6 +1045,10 @@ export namespace Prisma {
           updateMany: {
             args: Prisma.ProfileUpdateManyArgs<ExtArgs>;
             result: BatchPayload;
+          };
+          updateManyAndReturn: {
+            args: Prisma.ProfileUpdateManyAndReturnArgs<ExtArgs>;
+            result: $Utils.PayloadToResult<Prisma.$ProfilePayload>[];
           };
           upsert: {
             args: Prisma.ProfileUpsertArgs<ExtArgs>;
@@ -1102,6 +1120,10 @@ export namespace Prisma {
             args: Prisma.LocationUpdateManyArgs<ExtArgs>;
             result: BatchPayload;
           };
+          updateManyAndReturn: {
+            args: Prisma.LocationUpdateManyAndReturnArgs<ExtArgs>;
+            result: $Utils.PayloadToResult<Prisma.$LocationPayload>[];
+          };
           upsert: {
             args: Prisma.LocationUpsertArgs<ExtArgs>;
             result: $Utils.PayloadToResult<Prisma.$LocationPayload>;
@@ -1171,6 +1193,10 @@ export namespace Prisma {
           updateMany: {
             args: Prisma.CommentUpdateManyArgs<ExtArgs>;
             result: BatchPayload;
+          };
+          updateManyAndReturn: {
+            args: Prisma.CommentUpdateManyAndReturnArgs<ExtArgs>;
+            result: $Utils.PayloadToResult<Prisma.$CommentPayload>[];
           };
           upsert: {
             args: Prisma.CommentUpsertArgs<ExtArgs>;
@@ -1242,6 +1268,10 @@ export namespace Prisma {
             args: Prisma.TagUpdateManyArgs<ExtArgs>;
             result: BatchPayload;
           };
+          updateManyAndReturn: {
+            args: Prisma.TagUpdateManyAndReturnArgs<ExtArgs>;
+            result: $Utils.PayloadToResult<Prisma.$TagPayload>[];
+          };
           upsert: {
             args: Prisma.TagUpsertArgs<ExtArgs>;
             result: $Utils.PayloadToResult<Prisma.$TagPayload>;
@@ -1311,6 +1341,10 @@ export namespace Prisma {
           updateMany: {
             args: Prisma.TagGroupUpdateManyArgs<ExtArgs>;
             result: BatchPayload;
+          };
+          updateManyAndReturn: {
+            args: Prisma.TagGroupUpdateManyAndReturnArgs<ExtArgs>;
+            result: $Utils.PayloadToResult<Prisma.$TagGroupPayload>[];
           };
           upsert: {
             args: Prisma.TagGroupUpsertArgs<ExtArgs>;
@@ -1382,6 +1416,10 @@ export namespace Prisma {
             args: Prisma.EventUpdateManyArgs<ExtArgs>;
             result: BatchPayload;
           };
+          updateManyAndReturn: {
+            args: Prisma.EventUpdateManyAndReturnArgs<ExtArgs>;
+            result: $Utils.PayloadToResult<Prisma.$EventPayload>[];
+          };
           upsert: {
             args: Prisma.EventUpsertArgs<ExtArgs>;
             result: $Utils.PayloadToResult<Prisma.$EventPayload>;
@@ -1451,6 +1489,10 @@ export namespace Prisma {
           updateMany: {
             args: Prisma.EventFolderUpdateManyArgs<ExtArgs>;
             result: BatchPayload;
+          };
+          updateManyAndReturn: {
+            args: Prisma.EventFolderUpdateManyAndReturnArgs<ExtArgs>;
+            result: $Utils.PayloadToResult<Prisma.$EventFolderPayload>[];
           };
           upsert: {
             args: Prisma.EventFolderUpsertArgs<ExtArgs>;
@@ -1524,6 +1566,10 @@ export namespace Prisma {
             args: Prisma.MessageUpdateManyArgs<ExtArgs>;
             result: BatchPayload;
           };
+          updateManyAndReturn: {
+            args: Prisma.MessageUpdateManyAndReturnArgs<ExtArgs>;
+            result: $Utils.PayloadToResult<Prisma.$MessagePayload>[];
+          };
           upsert: {
             args: Prisma.MessageUpsertArgs<ExtArgs>;
             result: $Utils.PayloadToResult<Prisma.$MessagePayload>;
@@ -1593,6 +1639,10 @@ export namespace Prisma {
           updateMany: {
             args: Prisma.CannedResponseUpdateManyArgs<ExtArgs>;
             result: BatchPayload;
+          };
+          updateManyAndReturn: {
+            args: Prisma.CannedResponseUpdateManyAndReturnArgs<ExtArgs>;
+            result: $Utils.PayloadToResult<Prisma.$CannedResponsePayload>[];
           };
           upsert: {
             args: Prisma.CannedResponseUpsertArgs<ExtArgs>;
@@ -1665,6 +1715,10 @@ export namespace Prisma {
           updateMany: {
             args: Prisma.EnumsUpdateManyArgs<ExtArgs>;
             result: BatchPayload;
+          };
+          updateManyAndReturn: {
+            args: Prisma.EnumsUpdateManyAndReturnArgs<ExtArgs>;
+            result: $Utils.PayloadToResult<Prisma.$EnumsPayload>[];
           };
           upsert: {
             args: Prisma.EnumsUpsertArgs<ExtArgs>;
@@ -1755,7 +1809,35 @@ export namespace Prisma {
       timeout?: number;
       isolationLevel?: Prisma.TransactionIsolationLevel;
     };
+    /**
+     * Global configuration for omitting model fields by default.
+     *
+     * @example
+     * ```
+     * const prisma = new PrismaClient({
+     *   omit: {
+     *     user: {
+     *       password: true
+     *     }
+     *   }
+     * })
+     * ```
+     */
+    omit?: Prisma.GlobalOmitConfig;
   }
+  export type GlobalOmitConfig = {
+    account?: AccountOmit;
+    profile?: ProfileOmit;
+    location?: LocationOmit;
+    comment?: CommentOmit;
+    tag?: TagOmit;
+    tagGroup?: TagGroupOmit;
+    event?: EventOmit;
+    eventFolder?: EventFolderOmit;
+    message?: MessageOmit;
+    cannedResponse?: CannedResponseOmit;
+    enums?: EnumsOmit;
+  };
 
   /* Types for Logging */
   export type LogLevel = 'info' | 'query' | 'warn' | 'error';
@@ -1805,6 +1887,7 @@ export namespace Prisma {
     | 'createManyAndReturn'
     | 'update'
     | 'updateMany'
+    | 'updateManyAndReturn'
     | 'upsert'
     | 'delete'
     | 'deleteMany'
@@ -2421,6 +2504,22 @@ export namespace Prisma {
     ExtArgs['result']['account']
   >;
 
+  export type AccountSelectUpdateManyAndReturn<
+    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  > = $Extensions.GetSelect<
+    {
+      id?: boolean;
+      username?: boolean;
+      password?: boolean;
+      role?: boolean;
+      isGlobalFilterActive?: boolean;
+      fcmToken?: boolean;
+      created_at?: boolean;
+      updated_at?: boolean;
+    },
+    ExtArgs['result']['account']
+  >;
+
   export type AccountSelectScalar = {
     id?: boolean;
     username?: boolean;
@@ -2432,6 +2531,19 @@ export namespace Prisma {
     updated_at?: boolean;
   };
 
+  export type AccountOmit<
+    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  > = $Extensions.GetOmit<
+    | 'id'
+    | 'username'
+    | 'password'
+    | 'role'
+    | 'isGlobalFilterActive'
+    | 'fcmToken'
+    | 'created_at'
+    | 'updated_at',
+    ExtArgs['result']['account']
+  >;
   export type AccountInclude<
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
   > = {
@@ -2442,6 +2554,9 @@ export namespace Prisma {
     _count?: boolean | AccountCountOutputTypeDefaultArgs<ExtArgs>;
   };
   export type AccountIncludeCreateManyAndReturn<
+    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  > = {};
+  export type AccountIncludeUpdateManyAndReturn<
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
   > = {};
 
@@ -2477,12 +2592,13 @@ export namespace Prisma {
 
   type AccountCountArgs<
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
-  > = Omit<AccountFindManyArgs, 'select' | 'include' | 'distinct'> & {
+  > = Omit<AccountFindManyArgs, 'select' | 'include' | 'distinct' | 'omit'> & {
     select?: AccountCountAggregateInputType | true;
   };
 
   export interface AccountDelegate<
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+    ClientOptions = {},
   > {
     [K: symbol]: {
       types: Prisma.TypeMap<ExtArgs>['model']['Account'];
@@ -2505,10 +2621,12 @@ export namespace Prisma {
       $Result.GetResult<
         Prisma.$AccountPayload<ExtArgs>,
         T,
-        'findUnique'
+        'findUnique',
+        ClientOptions
       > | null,
       null,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -2529,10 +2647,12 @@ export namespace Prisma {
       $Result.GetResult<
         Prisma.$AccountPayload<ExtArgs>,
         T,
-        'findUniqueOrThrow'
+        'findUniqueOrThrow',
+        ClientOptions
       >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -2551,9 +2671,15 @@ export namespace Prisma {
     findFirst<T extends AccountFindFirstArgs>(
       args?: SelectSubset<T, AccountFindFirstArgs<ExtArgs>>,
     ): Prisma__AccountClient<
-      $Result.GetResult<Prisma.$AccountPayload<ExtArgs>, T, 'findFirst'> | null,
+      $Result.GetResult<
+        Prisma.$AccountPayload<ExtArgs>,
+        T,
+        'findFirst',
+        ClientOptions
+      > | null,
       null,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -2573,9 +2699,15 @@ export namespace Prisma {
     findFirstOrThrow<T extends AccountFindFirstOrThrowArgs>(
       args?: SelectSubset<T, AccountFindFirstOrThrowArgs<ExtArgs>>,
     ): Prisma__AccountClient<
-      $Result.GetResult<Prisma.$AccountPayload<ExtArgs>, T, 'findFirstOrThrow'>,
+      $Result.GetResult<
+        Prisma.$AccountPayload<ExtArgs>,
+        T,
+        'findFirstOrThrow',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -2597,7 +2729,12 @@ export namespace Prisma {
     findMany<T extends AccountFindManyArgs>(
       args?: SelectSubset<T, AccountFindManyArgs<ExtArgs>>,
     ): Prisma.PrismaPromise<
-      $Result.GetResult<Prisma.$AccountPayload<ExtArgs>, T, 'findMany'>
+      $Result.GetResult<
+        Prisma.$AccountPayload<ExtArgs>,
+        T,
+        'findMany',
+        ClientOptions
+      >
     >;
 
     /**
@@ -2615,9 +2752,15 @@ export namespace Prisma {
     create<T extends AccountCreateArgs>(
       args: SelectSubset<T, AccountCreateArgs<ExtArgs>>,
     ): Prisma__AccountClient<
-      $Result.GetResult<Prisma.$AccountPayload<ExtArgs>, T, 'create'>,
+      $Result.GetResult<
+        Prisma.$AccountPayload<ExtArgs>,
+        T,
+        'create',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -2664,7 +2807,8 @@ export namespace Prisma {
       $Result.GetResult<
         Prisma.$AccountPayload<ExtArgs>,
         T,
-        'createManyAndReturn'
+        'createManyAndReturn',
+        ClientOptions
       >
     >;
 
@@ -2683,9 +2827,15 @@ export namespace Prisma {
     delete<T extends AccountDeleteArgs>(
       args: SelectSubset<T, AccountDeleteArgs<ExtArgs>>,
     ): Prisma__AccountClient<
-      $Result.GetResult<Prisma.$AccountPayload<ExtArgs>, T, 'delete'>,
+      $Result.GetResult<
+        Prisma.$AccountPayload<ExtArgs>,
+        T,
+        'delete',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -2706,9 +2856,15 @@ export namespace Prisma {
     update<T extends AccountUpdateArgs>(
       args: SelectSubset<T, AccountUpdateArgs<ExtArgs>>,
     ): Prisma__AccountClient<
-      $Result.GetResult<Prisma.$AccountPayload<ExtArgs>, T, 'update'>,
+      $Result.GetResult<
+        Prisma.$AccountPayload<ExtArgs>,
+        T,
+        'update',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -2749,6 +2905,45 @@ export namespace Prisma {
     ): Prisma.PrismaPromise<BatchPayload>;
 
     /**
+     * Update zero or more Accounts and returns the data updated in the database.
+     * @param {AccountUpdateManyAndReturnArgs} args - Arguments to update many Accounts.
+     * @example
+     * // Update many Accounts
+     * const account = await prisma.account.updateManyAndReturn({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: [
+     *     // ... provide data here
+     *   ]
+     * })
+     *
+     * // Update zero or more Accounts and only return the `id`
+     * const accountWithIdOnly = await prisma.account.updateManyAndReturn({
+     *   select: { id: true },
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: [
+     *     // ... provide data here
+     *   ]
+     * })
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     *
+     */
+    updateManyAndReturn<T extends AccountUpdateManyAndReturnArgs>(
+      args: SelectSubset<T, AccountUpdateManyAndReturnArgs<ExtArgs>>,
+    ): Prisma.PrismaPromise<
+      $Result.GetResult<
+        Prisma.$AccountPayload<ExtArgs>,
+        T,
+        'updateManyAndReturn',
+        ClientOptions
+      >
+    >;
+
+    /**
      * Create or update one Account.
      * @param {AccountUpsertArgs} args - Arguments to update or create a Account.
      * @example
@@ -2768,9 +2963,15 @@ export namespace Prisma {
     upsert<T extends AccountUpsertArgs>(
       args: SelectSubset<T, AccountUpsertArgs<ExtArgs>>,
     ): Prisma__AccountClient<
-      $Result.GetResult<Prisma.$AccountPayload<ExtArgs>, T, 'upsert'>,
+      $Result.GetResult<
+        Prisma.$AccountPayload<ExtArgs>,
+        T,
+        'upsert',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -2922,27 +3123,52 @@ export namespace Prisma {
     T,
     Null = never,
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+    ClientOptions = {},
   > extends Prisma.PrismaPromise<T> {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     comments<T extends Account$commentsArgs<ExtArgs> = {}>(
       args?: Subset<T, Account$commentsArgs<ExtArgs>>,
     ): Prisma.PrismaPromise<
-      $Result.GetResult<Prisma.$CommentPayload<ExtArgs>, T, 'findMany'> | Null
+      | $Result.GetResult<
+          Prisma.$CommentPayload<ExtArgs>,
+          T,
+          'findMany',
+          ClientOptions
+        >
+      | Null
     >;
     solvableComments<T extends Account$solvableCommentsArgs<ExtArgs> = {}>(
       args?: Subset<T, Account$solvableCommentsArgs<ExtArgs>>,
     ): Prisma.PrismaPromise<
-      $Result.GetResult<Prisma.$CommentPayload<ExtArgs>, T, 'findMany'> | Null
+      | $Result.GetResult<
+          Prisma.$CommentPayload<ExtArgs>,
+          T,
+          'findMany',
+          ClientOptions
+        >
+      | Null
     >;
     tags<T extends Account$tagsArgs<ExtArgs> = {}>(
       args?: Subset<T, Account$tagsArgs<ExtArgs>>,
     ): Prisma.PrismaPromise<
-      $Result.GetResult<Prisma.$TagPayload<ExtArgs>, T, 'findMany'> | Null
+      | $Result.GetResult<
+          Prisma.$TagPayload<ExtArgs>,
+          T,
+          'findMany',
+          ClientOptions
+        >
+      | Null
     >;
     globalFilter<T extends Account$globalFilterArgs<ExtArgs> = {}>(
       args?: Subset<T, Account$globalFilterArgs<ExtArgs>>,
     ): Prisma.PrismaPromise<
-      $Result.GetResult<Prisma.$TagPayload<ExtArgs>, T, 'findMany'> | Null
+      | $Result.GetResult<
+          Prisma.$TagPayload<ExtArgs>,
+          T,
+          'findMany',
+          ClientOptions
+        >
+      | Null
     >;
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
@@ -3006,6 +3232,10 @@ export namespace Prisma {
      */
     select?: AccountSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Account
+     */
+    omit?: AccountOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: AccountInclude<ExtArgs> | null;
@@ -3026,6 +3256,10 @@ export namespace Prisma {
      */
     select?: AccountSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Account
+     */
+    omit?: AccountOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: AccountInclude<ExtArgs> | null;
@@ -3045,6 +3279,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the Account
      */
     select?: AccountSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Account
+     */
+    omit?: AccountOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -3098,6 +3336,10 @@ export namespace Prisma {
      */
     select?: AccountSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Account
+     */
+    omit?: AccountOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: AccountInclude<ExtArgs> | null;
@@ -3150,6 +3392,10 @@ export namespace Prisma {
      */
     select?: AccountSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Account
+     */
+    omit?: AccountOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: AccountInclude<ExtArgs> | null;
@@ -3197,6 +3443,10 @@ export namespace Prisma {
      */
     select?: AccountSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Account
+     */
+    omit?: AccountOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: AccountInclude<ExtArgs> | null;
@@ -3230,6 +3480,10 @@ export namespace Prisma {
      */
     select?: AccountSelectCreateManyAndReturn<ExtArgs> | null;
     /**
+     * Omit specific fields from the Account
+     */
+    omit?: AccountOmit<ExtArgs> | null;
+    /**
      * The data used to create many Accounts.
      */
     data: AccountCreateManyInput | AccountCreateManyInput[];
@@ -3246,6 +3500,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the Account
      */
     select?: AccountSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Account
+     */
+    omit?: AccountOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -3274,6 +3532,38 @@ export namespace Prisma {
      * Filter which Accounts to update
      */
     where?: AccountWhereInput;
+    /**
+     * Limit how many Accounts to update.
+     */
+    limit?: number;
+  };
+
+  /**
+   * Account updateManyAndReturn
+   */
+  export type AccountUpdateManyAndReturnArgs<
+    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  > = {
+    /**
+     * Select specific fields to fetch from the Account
+     */
+    select?: AccountSelectUpdateManyAndReturn<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Account
+     */
+    omit?: AccountOmit<ExtArgs> | null;
+    /**
+     * The data used to update Accounts.
+     */
+    data: XOR<AccountUpdateManyMutationInput, AccountUncheckedUpdateManyInput>;
+    /**
+     * Filter which Accounts to update
+     */
+    where?: AccountWhereInput;
+    /**
+     * Limit how many Accounts to update.
+     */
+    limit?: number;
   };
 
   /**
@@ -3286,6 +3576,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the Account
      */
     select?: AccountSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Account
+     */
+    omit?: AccountOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -3315,6 +3609,10 @@ export namespace Prisma {
      */
     select?: AccountSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Account
+     */
+    omit?: AccountOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: AccountInclude<ExtArgs> | null;
@@ -3334,6 +3632,10 @@ export namespace Prisma {
      * Filter which Accounts to delete
      */
     where?: AccountWhereInput;
+    /**
+     * Limit how many Accounts to delete.
+     */
+    limit?: number;
   };
 
   /**
@@ -3346,6 +3648,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the Comment
      */
     select?: CommentSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Comment
+     */
+    omit?: CommentOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -3371,6 +3677,10 @@ export namespace Prisma {
      */
     select?: CommentSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Comment
+     */
+    omit?: CommentOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: CommentInclude<ExtArgs> | null;
@@ -3395,6 +3705,10 @@ export namespace Prisma {
      */
     select?: TagSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Tag
+     */
+    omit?: TagOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: TagInclude<ExtArgs> | null;
@@ -3417,6 +3731,10 @@ export namespace Prisma {
      */
     select?: TagSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Tag
+     */
+    omit?: TagOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: TagInclude<ExtArgs> | null;
@@ -3438,6 +3756,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the Account
      */
     select?: AccountSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Account
+     */
+    omit?: AccountOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -3795,6 +4117,35 @@ export namespace Prisma {
     ExtArgs['result']['profile']
   >;
 
+  export type ProfileSelectUpdateManyAndReturn<
+    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  > = $Extensions.GetSelect<
+    {
+      id?: boolean;
+      shortId?: boolean;
+      phoneNumber?: boolean;
+      secondaryPhoneNumber?: boolean;
+      fullName?: boolean;
+      firstName?: boolean;
+      gender?: boolean;
+      birthDate?: boolean;
+      profilePictureUrl?: boolean;
+      instagram?: boolean;
+      mail?: boolean;
+      dni?: boolean;
+      alternativeNames?: boolean;
+      birthLocationId?: boolean;
+      residenceLocationId?: boolean;
+      isInTrash?: boolean;
+      movedToTrashDate?: boolean;
+      created_at?: boolean;
+      updated_at?: boolean;
+      birthLocation?: boolean | Profile$birthLocationArgs<ExtArgs>;
+      residenceLocation?: boolean | Profile$residenceLocationArgs<ExtArgs>;
+    },
+    ExtArgs['result']['profile']
+  >;
+
   export type ProfileSelectScalar = {
     id?: boolean;
     shortId?: boolean;
@@ -3817,6 +4168,30 @@ export namespace Prisma {
     updated_at?: boolean;
   };
 
+  export type ProfileOmit<
+    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  > = $Extensions.GetOmit<
+    | 'id'
+    | 'shortId'
+    | 'phoneNumber'
+    | 'secondaryPhoneNumber'
+    | 'fullName'
+    | 'firstName'
+    | 'gender'
+    | 'birthDate'
+    | 'profilePictureUrl'
+    | 'instagram'
+    | 'mail'
+    | 'dni'
+    | 'alternativeNames'
+    | 'birthLocationId'
+    | 'residenceLocationId'
+    | 'isInTrash'
+    | 'movedToTrashDate'
+    | 'created_at'
+    | 'updated_at',
+    ExtArgs['result']['profile']
+  >;
   export type ProfileInclude<
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
   > = {
@@ -3828,6 +4203,12 @@ export namespace Prisma {
     _count?: boolean | ProfileCountOutputTypeDefaultArgs<ExtArgs>;
   };
   export type ProfileIncludeCreateManyAndReturn<
+    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  > = {
+    birthLocation?: boolean | Profile$birthLocationArgs<ExtArgs>;
+    residenceLocation?: boolean | Profile$residenceLocationArgs<ExtArgs>;
+  };
+  export type ProfileIncludeUpdateManyAndReturn<
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
   > = {
     birthLocation?: boolean | Profile$birthLocationArgs<ExtArgs>;
@@ -3878,12 +4259,13 @@ export namespace Prisma {
 
   type ProfileCountArgs<
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
-  > = Omit<ProfileFindManyArgs, 'select' | 'include' | 'distinct'> & {
+  > = Omit<ProfileFindManyArgs, 'select' | 'include' | 'distinct' | 'omit'> & {
     select?: ProfileCountAggregateInputType | true;
   };
 
   export interface ProfileDelegate<
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+    ClientOptions = {},
   > {
     [K: symbol]: {
       types: Prisma.TypeMap<ExtArgs>['model']['Profile'];
@@ -3906,10 +4288,12 @@ export namespace Prisma {
       $Result.GetResult<
         Prisma.$ProfilePayload<ExtArgs>,
         T,
-        'findUnique'
+        'findUnique',
+        ClientOptions
       > | null,
       null,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -3930,10 +4314,12 @@ export namespace Prisma {
       $Result.GetResult<
         Prisma.$ProfilePayload<ExtArgs>,
         T,
-        'findUniqueOrThrow'
+        'findUniqueOrThrow',
+        ClientOptions
       >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -3952,9 +4338,15 @@ export namespace Prisma {
     findFirst<T extends ProfileFindFirstArgs>(
       args?: SelectSubset<T, ProfileFindFirstArgs<ExtArgs>>,
     ): Prisma__ProfileClient<
-      $Result.GetResult<Prisma.$ProfilePayload<ExtArgs>, T, 'findFirst'> | null,
+      $Result.GetResult<
+        Prisma.$ProfilePayload<ExtArgs>,
+        T,
+        'findFirst',
+        ClientOptions
+      > | null,
       null,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -3974,9 +4366,15 @@ export namespace Prisma {
     findFirstOrThrow<T extends ProfileFindFirstOrThrowArgs>(
       args?: SelectSubset<T, ProfileFindFirstOrThrowArgs<ExtArgs>>,
     ): Prisma__ProfileClient<
-      $Result.GetResult<Prisma.$ProfilePayload<ExtArgs>, T, 'findFirstOrThrow'>,
+      $Result.GetResult<
+        Prisma.$ProfilePayload<ExtArgs>,
+        T,
+        'findFirstOrThrow',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -3998,7 +4396,12 @@ export namespace Prisma {
     findMany<T extends ProfileFindManyArgs>(
       args?: SelectSubset<T, ProfileFindManyArgs<ExtArgs>>,
     ): Prisma.PrismaPromise<
-      $Result.GetResult<Prisma.$ProfilePayload<ExtArgs>, T, 'findMany'>
+      $Result.GetResult<
+        Prisma.$ProfilePayload<ExtArgs>,
+        T,
+        'findMany',
+        ClientOptions
+      >
     >;
 
     /**
@@ -4016,9 +4419,15 @@ export namespace Prisma {
     create<T extends ProfileCreateArgs>(
       args: SelectSubset<T, ProfileCreateArgs<ExtArgs>>,
     ): Prisma__ProfileClient<
-      $Result.GetResult<Prisma.$ProfilePayload<ExtArgs>, T, 'create'>,
+      $Result.GetResult<
+        Prisma.$ProfilePayload<ExtArgs>,
+        T,
+        'create',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -4065,7 +4474,8 @@ export namespace Prisma {
       $Result.GetResult<
         Prisma.$ProfilePayload<ExtArgs>,
         T,
-        'createManyAndReturn'
+        'createManyAndReturn',
+        ClientOptions
       >
     >;
 
@@ -4084,9 +4494,15 @@ export namespace Prisma {
     delete<T extends ProfileDeleteArgs>(
       args: SelectSubset<T, ProfileDeleteArgs<ExtArgs>>,
     ): Prisma__ProfileClient<
-      $Result.GetResult<Prisma.$ProfilePayload<ExtArgs>, T, 'delete'>,
+      $Result.GetResult<
+        Prisma.$ProfilePayload<ExtArgs>,
+        T,
+        'delete',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -4107,9 +4523,15 @@ export namespace Prisma {
     update<T extends ProfileUpdateArgs>(
       args: SelectSubset<T, ProfileUpdateArgs<ExtArgs>>,
     ): Prisma__ProfileClient<
-      $Result.GetResult<Prisma.$ProfilePayload<ExtArgs>, T, 'update'>,
+      $Result.GetResult<
+        Prisma.$ProfilePayload<ExtArgs>,
+        T,
+        'update',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -4150,6 +4572,45 @@ export namespace Prisma {
     ): Prisma.PrismaPromise<BatchPayload>;
 
     /**
+     * Update zero or more Profiles and returns the data updated in the database.
+     * @param {ProfileUpdateManyAndReturnArgs} args - Arguments to update many Profiles.
+     * @example
+     * // Update many Profiles
+     * const profile = await prisma.profile.updateManyAndReturn({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: [
+     *     // ... provide data here
+     *   ]
+     * })
+     *
+     * // Update zero or more Profiles and only return the `id`
+     * const profileWithIdOnly = await prisma.profile.updateManyAndReturn({
+     *   select: { id: true },
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: [
+     *     // ... provide data here
+     *   ]
+     * })
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     *
+     */
+    updateManyAndReturn<T extends ProfileUpdateManyAndReturnArgs>(
+      args: SelectSubset<T, ProfileUpdateManyAndReturnArgs<ExtArgs>>,
+    ): Prisma.PrismaPromise<
+      $Result.GetResult<
+        Prisma.$ProfilePayload<ExtArgs>,
+        T,
+        'updateManyAndReturn',
+        ClientOptions
+      >
+    >;
+
+    /**
      * Create or update one Profile.
      * @param {ProfileUpsertArgs} args - Arguments to update or create a Profile.
      * @example
@@ -4169,9 +4630,15 @@ export namespace Prisma {
     upsert<T extends ProfileUpsertArgs>(
       args: SelectSubset<T, ProfileUpsertArgs<ExtArgs>>,
     ): Prisma__ProfileClient<
-      $Result.GetResult<Prisma.$ProfilePayload<ExtArgs>, T, 'upsert'>,
+      $Result.GetResult<
+        Prisma.$ProfilePayload<ExtArgs>,
+        T,
+        'upsert',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -4323,22 +4790,41 @@ export namespace Prisma {
     T,
     Null = never,
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+    ClientOptions = {},
   > extends Prisma.PrismaPromise<T> {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     comments<T extends Profile$commentsArgs<ExtArgs> = {}>(
       args?: Subset<T, Profile$commentsArgs<ExtArgs>>,
     ): Prisma.PrismaPromise<
-      $Result.GetResult<Prisma.$CommentPayload<ExtArgs>, T, 'findMany'> | Null
+      | $Result.GetResult<
+          Prisma.$CommentPayload<ExtArgs>,
+          T,
+          'findMany',
+          ClientOptions
+        >
+      | Null
     >;
     messages<T extends Profile$messagesArgs<ExtArgs> = {}>(
       args?: Subset<T, Profile$messagesArgs<ExtArgs>>,
     ): Prisma.PrismaPromise<
-      $Result.GetResult<Prisma.$MessagePayload<ExtArgs>, T, 'findMany'> | Null
+      | $Result.GetResult<
+          Prisma.$MessagePayload<ExtArgs>,
+          T,
+          'findMany',
+          ClientOptions
+        >
+      | Null
     >;
     tags<T extends Profile$tagsArgs<ExtArgs> = {}>(
       args?: Subset<T, Profile$tagsArgs<ExtArgs>>,
     ): Prisma.PrismaPromise<
-      $Result.GetResult<Prisma.$TagPayload<ExtArgs>, T, 'findMany'> | Null
+      | $Result.GetResult<
+          Prisma.$TagPayload<ExtArgs>,
+          T,
+          'findMany',
+          ClientOptions
+        >
+      | Null
     >;
     birthLocation<T extends Profile$birthLocationArgs<ExtArgs> = {}>(
       args?: Subset<T, Profile$birthLocationArgs<ExtArgs>>,
@@ -4346,10 +4832,12 @@ export namespace Prisma {
       $Result.GetResult<
         Prisma.$LocationPayload<ExtArgs>,
         T,
-        'findUniqueOrThrow'
+        'findUniqueOrThrow',
+        ClientOptions
       > | null,
       null,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
     residenceLocation<T extends Profile$residenceLocationArgs<ExtArgs> = {}>(
       args?: Subset<T, Profile$residenceLocationArgs<ExtArgs>>,
@@ -4357,10 +4845,12 @@ export namespace Prisma {
       $Result.GetResult<
         Prisma.$LocationPayload<ExtArgs>,
         T,
-        'findUniqueOrThrow'
+        'findUniqueOrThrow',
+        ClientOptions
       > | null,
       null,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
@@ -4435,6 +4925,10 @@ export namespace Prisma {
      */
     select?: ProfileSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Profile
+     */
+    omit?: ProfileOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: ProfileInclude<ExtArgs> | null;
@@ -4455,6 +4949,10 @@ export namespace Prisma {
      */
     select?: ProfileSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Profile
+     */
+    omit?: ProfileOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: ProfileInclude<ExtArgs> | null;
@@ -4474,6 +4972,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the Profile
      */
     select?: ProfileSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Profile
+     */
+    omit?: ProfileOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -4527,6 +5029,10 @@ export namespace Prisma {
      */
     select?: ProfileSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Profile
+     */
+    omit?: ProfileOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: ProfileInclude<ExtArgs> | null;
@@ -4579,6 +5085,10 @@ export namespace Prisma {
      */
     select?: ProfileSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Profile
+     */
+    omit?: ProfileOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: ProfileInclude<ExtArgs> | null;
@@ -4626,6 +5136,10 @@ export namespace Prisma {
      */
     select?: ProfileSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Profile
+     */
+    omit?: ProfileOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: ProfileInclude<ExtArgs> | null;
@@ -4659,6 +5173,10 @@ export namespace Prisma {
      */
     select?: ProfileSelectCreateManyAndReturn<ExtArgs> | null;
     /**
+     * Omit specific fields from the Profile
+     */
+    omit?: ProfileOmit<ExtArgs> | null;
+    /**
      * The data used to create many Profiles.
      */
     data: ProfileCreateManyInput | ProfileCreateManyInput[];
@@ -4679,6 +5197,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the Profile
      */
     select?: ProfileSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Profile
+     */
+    omit?: ProfileOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -4707,6 +5229,42 @@ export namespace Prisma {
      * Filter which Profiles to update
      */
     where?: ProfileWhereInput;
+    /**
+     * Limit how many Profiles to update.
+     */
+    limit?: number;
+  };
+
+  /**
+   * Profile updateManyAndReturn
+   */
+  export type ProfileUpdateManyAndReturnArgs<
+    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  > = {
+    /**
+     * Select specific fields to fetch from the Profile
+     */
+    select?: ProfileSelectUpdateManyAndReturn<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Profile
+     */
+    omit?: ProfileOmit<ExtArgs> | null;
+    /**
+     * The data used to update Profiles.
+     */
+    data: XOR<ProfileUpdateManyMutationInput, ProfileUncheckedUpdateManyInput>;
+    /**
+     * Filter which Profiles to update
+     */
+    where?: ProfileWhereInput;
+    /**
+     * Limit how many Profiles to update.
+     */
+    limit?: number;
+    /**
+     * Choose, which related nodes to fetch as well
+     */
+    include?: ProfileIncludeUpdateManyAndReturn<ExtArgs> | null;
   };
 
   /**
@@ -4719,6 +5277,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the Profile
      */
     select?: ProfileSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Profile
+     */
+    omit?: ProfileOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -4748,6 +5310,10 @@ export namespace Prisma {
      */
     select?: ProfileSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Profile
+     */
+    omit?: ProfileOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: ProfileInclude<ExtArgs> | null;
@@ -4767,6 +5333,10 @@ export namespace Prisma {
      * Filter which Profiles to delete
      */
     where?: ProfileWhereInput;
+    /**
+     * Limit how many Profiles to delete.
+     */
+    limit?: number;
   };
 
   /**
@@ -4779,6 +5349,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the Comment
      */
     select?: CommentSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Comment
+     */
+    omit?: CommentOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -4804,6 +5378,10 @@ export namespace Prisma {
      */
     select?: MessageSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Message
+     */
+    omit?: MessageOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: MessageInclude<ExtArgs> | null;
@@ -4828,6 +5406,10 @@ export namespace Prisma {
      */
     select?: TagSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Tag
+     */
+    omit?: TagOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: TagInclude<ExtArgs> | null;
@@ -4850,6 +5432,10 @@ export namespace Prisma {
      */
     select?: LocationSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Location
+     */
+    omit?: LocationOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: LocationInclude<ExtArgs> | null;
@@ -4867,6 +5453,10 @@ export namespace Prisma {
      */
     select?: LocationSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Location
+     */
+    omit?: LocationOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: LocationInclude<ExtArgs> | null;
@@ -4883,6 +5473,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the Profile
      */
     select?: ProfileSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Profile
+     */
+    omit?: ProfileOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -5144,6 +5738,22 @@ export namespace Prisma {
     ExtArgs['result']['location']
   >;
 
+  export type LocationSelectUpdateManyAndReturn<
+    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  > = $Extensions.GetSelect<
+    {
+      id?: boolean;
+      latitude?: boolean;
+      longitude?: boolean;
+      country?: boolean;
+      state?: boolean;
+      city?: boolean;
+      created_at?: boolean;
+      updated_at?: boolean;
+    },
+    ExtArgs['result']['location']
+  >;
+
   export type LocationSelectScalar = {
     id?: boolean;
     latitude?: boolean;
@@ -5155,6 +5765,19 @@ export namespace Prisma {
     updated_at?: boolean;
   };
 
+  export type LocationOmit<
+    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  > = $Extensions.GetOmit<
+    | 'id'
+    | 'latitude'
+    | 'longitude'
+    | 'country'
+    | 'state'
+    | 'city'
+    | 'created_at'
+    | 'updated_at',
+    ExtArgs['result']['location']
+  >;
   export type LocationInclude<
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
   > = {
@@ -5163,6 +5786,9 @@ export namespace Prisma {
     _count?: boolean | LocationCountOutputTypeDefaultArgs<ExtArgs>;
   };
   export type LocationIncludeCreateManyAndReturn<
+    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  > = {};
+  export type LocationIncludeUpdateManyAndReturn<
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
   > = {};
 
@@ -5196,12 +5822,13 @@ export namespace Prisma {
 
   type LocationCountArgs<
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
-  > = Omit<LocationFindManyArgs, 'select' | 'include' | 'distinct'> & {
+  > = Omit<LocationFindManyArgs, 'select' | 'include' | 'distinct' | 'omit'> & {
     select?: LocationCountAggregateInputType | true;
   };
 
   export interface LocationDelegate<
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+    ClientOptions = {},
   > {
     [K: symbol]: {
       types: Prisma.TypeMap<ExtArgs>['model']['Location'];
@@ -5224,10 +5851,12 @@ export namespace Prisma {
       $Result.GetResult<
         Prisma.$LocationPayload<ExtArgs>,
         T,
-        'findUnique'
+        'findUnique',
+        ClientOptions
       > | null,
       null,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -5248,10 +5877,12 @@ export namespace Prisma {
       $Result.GetResult<
         Prisma.$LocationPayload<ExtArgs>,
         T,
-        'findUniqueOrThrow'
+        'findUniqueOrThrow',
+        ClientOptions
       >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -5273,10 +5904,12 @@ export namespace Prisma {
       $Result.GetResult<
         Prisma.$LocationPayload<ExtArgs>,
         T,
-        'findFirst'
+        'findFirst',
+        ClientOptions
       > | null,
       null,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -5299,10 +5932,12 @@ export namespace Prisma {
       $Result.GetResult<
         Prisma.$LocationPayload<ExtArgs>,
         T,
-        'findFirstOrThrow'
+        'findFirstOrThrow',
+        ClientOptions
       >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -5324,7 +5959,12 @@ export namespace Prisma {
     findMany<T extends LocationFindManyArgs>(
       args?: SelectSubset<T, LocationFindManyArgs<ExtArgs>>,
     ): Prisma.PrismaPromise<
-      $Result.GetResult<Prisma.$LocationPayload<ExtArgs>, T, 'findMany'>
+      $Result.GetResult<
+        Prisma.$LocationPayload<ExtArgs>,
+        T,
+        'findMany',
+        ClientOptions
+      >
     >;
 
     /**
@@ -5342,9 +5982,15 @@ export namespace Prisma {
     create<T extends LocationCreateArgs>(
       args: SelectSubset<T, LocationCreateArgs<ExtArgs>>,
     ): Prisma__LocationClient<
-      $Result.GetResult<Prisma.$LocationPayload<ExtArgs>, T, 'create'>,
+      $Result.GetResult<
+        Prisma.$LocationPayload<ExtArgs>,
+        T,
+        'create',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -5391,7 +6037,8 @@ export namespace Prisma {
       $Result.GetResult<
         Prisma.$LocationPayload<ExtArgs>,
         T,
-        'createManyAndReturn'
+        'createManyAndReturn',
+        ClientOptions
       >
     >;
 
@@ -5410,9 +6057,15 @@ export namespace Prisma {
     delete<T extends LocationDeleteArgs>(
       args: SelectSubset<T, LocationDeleteArgs<ExtArgs>>,
     ): Prisma__LocationClient<
-      $Result.GetResult<Prisma.$LocationPayload<ExtArgs>, T, 'delete'>,
+      $Result.GetResult<
+        Prisma.$LocationPayload<ExtArgs>,
+        T,
+        'delete',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -5433,9 +6086,15 @@ export namespace Prisma {
     update<T extends LocationUpdateArgs>(
       args: SelectSubset<T, LocationUpdateArgs<ExtArgs>>,
     ): Prisma__LocationClient<
-      $Result.GetResult<Prisma.$LocationPayload<ExtArgs>, T, 'update'>,
+      $Result.GetResult<
+        Prisma.$LocationPayload<ExtArgs>,
+        T,
+        'update',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -5476,6 +6135,45 @@ export namespace Prisma {
     ): Prisma.PrismaPromise<BatchPayload>;
 
     /**
+     * Update zero or more Locations and returns the data updated in the database.
+     * @param {LocationUpdateManyAndReturnArgs} args - Arguments to update many Locations.
+     * @example
+     * // Update many Locations
+     * const location = await prisma.location.updateManyAndReturn({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: [
+     *     // ... provide data here
+     *   ]
+     * })
+     *
+     * // Update zero or more Locations and only return the `id`
+     * const locationWithIdOnly = await prisma.location.updateManyAndReturn({
+     *   select: { id: true },
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: [
+     *     // ... provide data here
+     *   ]
+     * })
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     *
+     */
+    updateManyAndReturn<T extends LocationUpdateManyAndReturnArgs>(
+      args: SelectSubset<T, LocationUpdateManyAndReturnArgs<ExtArgs>>,
+    ): Prisma.PrismaPromise<
+      $Result.GetResult<
+        Prisma.$LocationPayload<ExtArgs>,
+        T,
+        'updateManyAndReturn',
+        ClientOptions
+      >
+    >;
+
+    /**
      * Create or update one Location.
      * @param {LocationUpsertArgs} args - Arguments to update or create a Location.
      * @example
@@ -5495,9 +6193,15 @@ export namespace Prisma {
     upsert<T extends LocationUpsertArgs>(
       args: SelectSubset<T, LocationUpsertArgs<ExtArgs>>,
     ): Prisma__LocationClient<
-      $Result.GetResult<Prisma.$LocationPayload<ExtArgs>, T, 'upsert'>,
+      $Result.GetResult<
+        Prisma.$LocationPayload<ExtArgs>,
+        T,
+        'upsert',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -5650,17 +6354,30 @@ export namespace Prisma {
     T,
     Null = never,
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+    ClientOptions = {},
   > extends Prisma.PrismaPromise<T> {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     birthProfiles<T extends Location$birthProfilesArgs<ExtArgs> = {}>(
       args?: Subset<T, Location$birthProfilesArgs<ExtArgs>>,
     ): Prisma.PrismaPromise<
-      $Result.GetResult<Prisma.$ProfilePayload<ExtArgs>, T, 'findMany'> | Null
+      | $Result.GetResult<
+          Prisma.$ProfilePayload<ExtArgs>,
+          T,
+          'findMany',
+          ClientOptions
+        >
+      | Null
     >;
     residenceProfiles<T extends Location$residenceProfilesArgs<ExtArgs> = {}>(
       args?: Subset<T, Location$residenceProfilesArgs<ExtArgs>>,
     ): Prisma.PrismaPromise<
-      $Result.GetResult<Prisma.$ProfilePayload<ExtArgs>, T, 'findMany'> | Null
+      | $Result.GetResult<
+          Prisma.$ProfilePayload<ExtArgs>,
+          T,
+          'findMany',
+          ClientOptions
+        >
+      | Null
     >;
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
@@ -5724,6 +6441,10 @@ export namespace Prisma {
      */
     select?: LocationSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Location
+     */
+    omit?: LocationOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: LocationInclude<ExtArgs> | null;
@@ -5744,6 +6465,10 @@ export namespace Prisma {
      */
     select?: LocationSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Location
+     */
+    omit?: LocationOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: LocationInclude<ExtArgs> | null;
@@ -5763,6 +6488,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the Location
      */
     select?: LocationSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Location
+     */
+    omit?: LocationOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -5816,6 +6545,10 @@ export namespace Prisma {
      */
     select?: LocationSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Location
+     */
+    omit?: LocationOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: LocationInclude<ExtArgs> | null;
@@ -5868,6 +6601,10 @@ export namespace Prisma {
      */
     select?: LocationSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Location
+     */
+    omit?: LocationOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: LocationInclude<ExtArgs> | null;
@@ -5915,6 +6652,10 @@ export namespace Prisma {
      */
     select?: LocationSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Location
+     */
+    omit?: LocationOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: LocationInclude<ExtArgs> | null;
@@ -5948,6 +6689,10 @@ export namespace Prisma {
      */
     select?: LocationSelectCreateManyAndReturn<ExtArgs> | null;
     /**
+     * Omit specific fields from the Location
+     */
+    omit?: LocationOmit<ExtArgs> | null;
+    /**
      * The data used to create many Locations.
      */
     data: LocationCreateManyInput | LocationCreateManyInput[];
@@ -5964,6 +6709,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the Location
      */
     select?: LocationSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Location
+     */
+    omit?: LocationOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -5995,6 +6744,41 @@ export namespace Prisma {
      * Filter which Locations to update
      */
     where?: LocationWhereInput;
+    /**
+     * Limit how many Locations to update.
+     */
+    limit?: number;
+  };
+
+  /**
+   * Location updateManyAndReturn
+   */
+  export type LocationUpdateManyAndReturnArgs<
+    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  > = {
+    /**
+     * Select specific fields to fetch from the Location
+     */
+    select?: LocationSelectUpdateManyAndReturn<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Location
+     */
+    omit?: LocationOmit<ExtArgs> | null;
+    /**
+     * The data used to update Locations.
+     */
+    data: XOR<
+      LocationUpdateManyMutationInput,
+      LocationUncheckedUpdateManyInput
+    >;
+    /**
+     * Filter which Locations to update
+     */
+    where?: LocationWhereInput;
+    /**
+     * Limit how many Locations to update.
+     */
+    limit?: number;
   };
 
   /**
@@ -6007,6 +6791,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the Location
      */
     select?: LocationSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Location
+     */
+    omit?: LocationOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -6036,6 +6824,10 @@ export namespace Prisma {
      */
     select?: LocationSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Location
+     */
+    omit?: LocationOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: LocationInclude<ExtArgs> | null;
@@ -6055,6 +6847,10 @@ export namespace Prisma {
      * Filter which Locations to delete
      */
     where?: LocationWhereInput;
+    /**
+     * Limit how many Locations to delete.
+     */
+    limit?: number;
   };
 
   /**
@@ -6067,6 +6863,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the Profile
      */
     select?: ProfileSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Profile
+     */
+    omit?: ProfileOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -6092,6 +6892,10 @@ export namespace Prisma {
      */
     select?: ProfileSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Profile
+     */
+    omit?: ProfileOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: ProfileInclude<ExtArgs> | null;
@@ -6115,6 +6919,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the Location
      */
     select?: LocationSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Location
+     */
+    omit?: LocationOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -6359,6 +7167,27 @@ export namespace Prisma {
     ExtArgs['result']['comment']
   >;
 
+  export type CommentSelectUpdateManyAndReturn<
+    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  > = $Extensions.GetSelect<
+    {
+      id?: boolean;
+      content?: boolean;
+      createdBy?: boolean;
+      profileId?: boolean;
+      isSolvable?: boolean;
+      isSolved?: boolean;
+      solvedAt?: boolean;
+      solvedById?: boolean;
+      created_at?: boolean;
+      updated_at?: boolean;
+      account?: boolean | AccountDefaultArgs<ExtArgs>;
+      profile?: boolean | ProfileDefaultArgs<ExtArgs>;
+      solvedBy?: boolean | Comment$solvedByArgs<ExtArgs>;
+    },
+    ExtArgs['result']['comment']
+  >;
+
   export type CommentSelectScalar = {
     id?: boolean;
     content?: boolean;
@@ -6372,6 +7201,21 @@ export namespace Prisma {
     updated_at?: boolean;
   };
 
+  export type CommentOmit<
+    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  > = $Extensions.GetOmit<
+    | 'id'
+    | 'content'
+    | 'createdBy'
+    | 'profileId'
+    | 'isSolvable'
+    | 'isSolved'
+    | 'solvedAt'
+    | 'solvedById'
+    | 'created_at'
+    | 'updated_at',
+    ExtArgs['result']['comment']
+  >;
   export type CommentInclude<
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
   > = {
@@ -6380,6 +7224,13 @@ export namespace Prisma {
     solvedBy?: boolean | Comment$solvedByArgs<ExtArgs>;
   };
   export type CommentIncludeCreateManyAndReturn<
+    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  > = {
+    account?: boolean | AccountDefaultArgs<ExtArgs>;
+    profile?: boolean | ProfileDefaultArgs<ExtArgs>;
+    solvedBy?: boolean | Comment$solvedByArgs<ExtArgs>;
+  };
+  export type CommentIncludeUpdateManyAndReturn<
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
   > = {
     account?: boolean | AccountDefaultArgs<ExtArgs>;
@@ -6420,12 +7271,13 @@ export namespace Prisma {
 
   type CommentCountArgs<
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
-  > = Omit<CommentFindManyArgs, 'select' | 'include' | 'distinct'> & {
+  > = Omit<CommentFindManyArgs, 'select' | 'include' | 'distinct' | 'omit'> & {
     select?: CommentCountAggregateInputType | true;
   };
 
   export interface CommentDelegate<
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+    ClientOptions = {},
   > {
     [K: symbol]: {
       types: Prisma.TypeMap<ExtArgs>['model']['Comment'];
@@ -6448,10 +7300,12 @@ export namespace Prisma {
       $Result.GetResult<
         Prisma.$CommentPayload<ExtArgs>,
         T,
-        'findUnique'
+        'findUnique',
+        ClientOptions
       > | null,
       null,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -6472,10 +7326,12 @@ export namespace Prisma {
       $Result.GetResult<
         Prisma.$CommentPayload<ExtArgs>,
         T,
-        'findUniqueOrThrow'
+        'findUniqueOrThrow',
+        ClientOptions
       >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -6494,9 +7350,15 @@ export namespace Prisma {
     findFirst<T extends CommentFindFirstArgs>(
       args?: SelectSubset<T, CommentFindFirstArgs<ExtArgs>>,
     ): Prisma__CommentClient<
-      $Result.GetResult<Prisma.$CommentPayload<ExtArgs>, T, 'findFirst'> | null,
+      $Result.GetResult<
+        Prisma.$CommentPayload<ExtArgs>,
+        T,
+        'findFirst',
+        ClientOptions
+      > | null,
       null,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -6516,9 +7378,15 @@ export namespace Prisma {
     findFirstOrThrow<T extends CommentFindFirstOrThrowArgs>(
       args?: SelectSubset<T, CommentFindFirstOrThrowArgs<ExtArgs>>,
     ): Prisma__CommentClient<
-      $Result.GetResult<Prisma.$CommentPayload<ExtArgs>, T, 'findFirstOrThrow'>,
+      $Result.GetResult<
+        Prisma.$CommentPayload<ExtArgs>,
+        T,
+        'findFirstOrThrow',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -6540,7 +7408,12 @@ export namespace Prisma {
     findMany<T extends CommentFindManyArgs>(
       args?: SelectSubset<T, CommentFindManyArgs<ExtArgs>>,
     ): Prisma.PrismaPromise<
-      $Result.GetResult<Prisma.$CommentPayload<ExtArgs>, T, 'findMany'>
+      $Result.GetResult<
+        Prisma.$CommentPayload<ExtArgs>,
+        T,
+        'findMany',
+        ClientOptions
+      >
     >;
 
     /**
@@ -6558,9 +7431,15 @@ export namespace Prisma {
     create<T extends CommentCreateArgs>(
       args: SelectSubset<T, CommentCreateArgs<ExtArgs>>,
     ): Prisma__CommentClient<
-      $Result.GetResult<Prisma.$CommentPayload<ExtArgs>, T, 'create'>,
+      $Result.GetResult<
+        Prisma.$CommentPayload<ExtArgs>,
+        T,
+        'create',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -6607,7 +7486,8 @@ export namespace Prisma {
       $Result.GetResult<
         Prisma.$CommentPayload<ExtArgs>,
         T,
-        'createManyAndReturn'
+        'createManyAndReturn',
+        ClientOptions
       >
     >;
 
@@ -6626,9 +7506,15 @@ export namespace Prisma {
     delete<T extends CommentDeleteArgs>(
       args: SelectSubset<T, CommentDeleteArgs<ExtArgs>>,
     ): Prisma__CommentClient<
-      $Result.GetResult<Prisma.$CommentPayload<ExtArgs>, T, 'delete'>,
+      $Result.GetResult<
+        Prisma.$CommentPayload<ExtArgs>,
+        T,
+        'delete',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -6649,9 +7535,15 @@ export namespace Prisma {
     update<T extends CommentUpdateArgs>(
       args: SelectSubset<T, CommentUpdateArgs<ExtArgs>>,
     ): Prisma__CommentClient<
-      $Result.GetResult<Prisma.$CommentPayload<ExtArgs>, T, 'update'>,
+      $Result.GetResult<
+        Prisma.$CommentPayload<ExtArgs>,
+        T,
+        'update',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -6692,6 +7584,45 @@ export namespace Prisma {
     ): Prisma.PrismaPromise<BatchPayload>;
 
     /**
+     * Update zero or more Comments and returns the data updated in the database.
+     * @param {CommentUpdateManyAndReturnArgs} args - Arguments to update many Comments.
+     * @example
+     * // Update many Comments
+     * const comment = await prisma.comment.updateManyAndReturn({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: [
+     *     // ... provide data here
+     *   ]
+     * })
+     *
+     * // Update zero or more Comments and only return the `id`
+     * const commentWithIdOnly = await prisma.comment.updateManyAndReturn({
+     *   select: { id: true },
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: [
+     *     // ... provide data here
+     *   ]
+     * })
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     *
+     */
+    updateManyAndReturn<T extends CommentUpdateManyAndReturnArgs>(
+      args: SelectSubset<T, CommentUpdateManyAndReturnArgs<ExtArgs>>,
+    ): Prisma.PrismaPromise<
+      $Result.GetResult<
+        Prisma.$CommentPayload<ExtArgs>,
+        T,
+        'updateManyAndReturn',
+        ClientOptions
+      >
+    >;
+
+    /**
      * Create or update one Comment.
      * @param {CommentUpsertArgs} args - Arguments to update or create a Comment.
      * @example
@@ -6711,9 +7642,15 @@ export namespace Prisma {
     upsert<T extends CommentUpsertArgs>(
       args: SelectSubset<T, CommentUpsertArgs<ExtArgs>>,
     ): Prisma__CommentClient<
-      $Result.GetResult<Prisma.$CommentPayload<ExtArgs>, T, 'upsert'>,
+      $Result.GetResult<
+        Prisma.$CommentPayload<ExtArgs>,
+        T,
+        'upsert',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -6865,6 +7802,7 @@ export namespace Prisma {
     T,
     Null = never,
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+    ClientOptions = {},
   > extends Prisma.PrismaPromise<T> {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     account<T extends AccountDefaultArgs<ExtArgs> = {}>(
@@ -6873,11 +7811,13 @@ export namespace Prisma {
       | $Result.GetResult<
           Prisma.$AccountPayload<ExtArgs>,
           T,
-          'findUniqueOrThrow'
+          'findUniqueOrThrow',
+          ClientOptions
         >
       | Null,
       Null,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
     profile<T extends ProfileDefaultArgs<ExtArgs> = {}>(
       args?: Subset<T, ProfileDefaultArgs<ExtArgs>>,
@@ -6885,11 +7825,13 @@ export namespace Prisma {
       | $Result.GetResult<
           Prisma.$ProfilePayload<ExtArgs>,
           T,
-          'findUniqueOrThrow'
+          'findUniqueOrThrow',
+          ClientOptions
         >
       | Null,
       Null,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
     solvedBy<T extends Comment$solvedByArgs<ExtArgs> = {}>(
       args?: Subset<T, Comment$solvedByArgs<ExtArgs>>,
@@ -6897,10 +7839,12 @@ export namespace Prisma {
       $Result.GetResult<
         Prisma.$AccountPayload<ExtArgs>,
         T,
-        'findUniqueOrThrow'
+        'findUniqueOrThrow',
+        ClientOptions
       > | null,
       null,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
@@ -6966,6 +7910,10 @@ export namespace Prisma {
      */
     select?: CommentSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Comment
+     */
+    omit?: CommentOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: CommentInclude<ExtArgs> | null;
@@ -6986,6 +7934,10 @@ export namespace Prisma {
      */
     select?: CommentSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Comment
+     */
+    omit?: CommentOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: CommentInclude<ExtArgs> | null;
@@ -7005,6 +7957,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the Comment
      */
     select?: CommentSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Comment
+     */
+    omit?: CommentOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -7058,6 +8014,10 @@ export namespace Prisma {
      */
     select?: CommentSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Comment
+     */
+    omit?: CommentOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: CommentInclude<ExtArgs> | null;
@@ -7110,6 +8070,10 @@ export namespace Prisma {
      */
     select?: CommentSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Comment
+     */
+    omit?: CommentOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: CommentInclude<ExtArgs> | null;
@@ -7157,6 +8121,10 @@ export namespace Prisma {
      */
     select?: CommentSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Comment
+     */
+    omit?: CommentOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: CommentInclude<ExtArgs> | null;
@@ -7190,6 +8158,10 @@ export namespace Prisma {
      */
     select?: CommentSelectCreateManyAndReturn<ExtArgs> | null;
     /**
+     * Omit specific fields from the Comment
+     */
+    omit?: CommentOmit<ExtArgs> | null;
+    /**
      * The data used to create many Comments.
      */
     data: CommentCreateManyInput | CommentCreateManyInput[];
@@ -7210,6 +8182,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the Comment
      */
     select?: CommentSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Comment
+     */
+    omit?: CommentOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -7238,6 +8214,42 @@ export namespace Prisma {
      * Filter which Comments to update
      */
     where?: CommentWhereInput;
+    /**
+     * Limit how many Comments to update.
+     */
+    limit?: number;
+  };
+
+  /**
+   * Comment updateManyAndReturn
+   */
+  export type CommentUpdateManyAndReturnArgs<
+    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  > = {
+    /**
+     * Select specific fields to fetch from the Comment
+     */
+    select?: CommentSelectUpdateManyAndReturn<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Comment
+     */
+    omit?: CommentOmit<ExtArgs> | null;
+    /**
+     * The data used to update Comments.
+     */
+    data: XOR<CommentUpdateManyMutationInput, CommentUncheckedUpdateManyInput>;
+    /**
+     * Filter which Comments to update
+     */
+    where?: CommentWhereInput;
+    /**
+     * Limit how many Comments to update.
+     */
+    limit?: number;
+    /**
+     * Choose, which related nodes to fetch as well
+     */
+    include?: CommentIncludeUpdateManyAndReturn<ExtArgs> | null;
   };
 
   /**
@@ -7250,6 +8262,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the Comment
      */
     select?: CommentSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Comment
+     */
+    omit?: CommentOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -7279,6 +8295,10 @@ export namespace Prisma {
      */
     select?: CommentSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Comment
+     */
+    omit?: CommentOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: CommentInclude<ExtArgs> | null;
@@ -7298,6 +8318,10 @@ export namespace Prisma {
      * Filter which Comments to delete
      */
     where?: CommentWhereInput;
+    /**
+     * Limit how many Comments to delete.
+     */
+    limit?: number;
   };
 
   /**
@@ -7310,6 +8334,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the Account
      */
     select?: AccountSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Account
+     */
+    omit?: AccountOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -7327,6 +8355,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the Comment
      */
     select?: CommentSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Comment
+     */
+    omit?: CommentOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -7532,6 +8564,21 @@ export namespace Prisma {
     ExtArgs['result']['tag']
   >;
 
+  export type TagSelectUpdateManyAndReturn<
+    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  > = $Extensions.GetSelect<
+    {
+      id?: boolean;
+      name?: boolean;
+      type?: boolean;
+      groupId?: boolean;
+      created_at?: boolean;
+      updated_at?: boolean;
+      group?: boolean | TagGroupDefaultArgs<ExtArgs>;
+    },
+    ExtArgs['result']['tag']
+  >;
+
   export type TagSelectScalar = {
     id?: boolean;
     name?: boolean;
@@ -7541,6 +8588,12 @@ export namespace Prisma {
     updated_at?: boolean;
   };
 
+  export type TagOmit<
+    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  > = $Extensions.GetOmit<
+    'id' | 'name' | 'type' | 'groupId' | 'created_at' | 'updated_at',
+    ExtArgs['result']['tag']
+  >;
   export type TagInclude<
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
   > = {
@@ -7553,6 +8606,11 @@ export namespace Prisma {
     _count?: boolean | TagCountOutputTypeDefaultArgs<ExtArgs>;
   };
   export type TagIncludeCreateManyAndReturn<
+    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  > = {
+    group?: boolean | TagGroupDefaultArgs<ExtArgs>;
+  };
+  export type TagIncludeUpdateManyAndReturn<
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
   > = {
     group?: boolean | TagGroupDefaultArgs<ExtArgs>;
@@ -7589,12 +8647,13 @@ export namespace Prisma {
 
   type TagCountArgs<
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
-  > = Omit<TagFindManyArgs, 'select' | 'include' | 'distinct'> & {
+  > = Omit<TagFindManyArgs, 'select' | 'include' | 'distinct' | 'omit'> & {
     select?: TagCountAggregateInputType | true;
   };
 
   export interface TagDelegate<
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+    ClientOptions = {},
   > {
     [K: symbol]: {
       types: Prisma.TypeMap<ExtArgs>['model']['Tag'];
@@ -7614,9 +8673,15 @@ export namespace Prisma {
     findUnique<T extends TagFindUniqueArgs>(
       args: SelectSubset<T, TagFindUniqueArgs<ExtArgs>>,
     ): Prisma__TagClient<
-      $Result.GetResult<Prisma.$TagPayload<ExtArgs>, T, 'findUnique'> | null,
+      $Result.GetResult<
+        Prisma.$TagPayload<ExtArgs>,
+        T,
+        'findUnique',
+        ClientOptions
+      > | null,
       null,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -7634,9 +8699,15 @@ export namespace Prisma {
     findUniqueOrThrow<T extends TagFindUniqueOrThrowArgs>(
       args: SelectSubset<T, TagFindUniqueOrThrowArgs<ExtArgs>>,
     ): Prisma__TagClient<
-      $Result.GetResult<Prisma.$TagPayload<ExtArgs>, T, 'findUniqueOrThrow'>,
+      $Result.GetResult<
+        Prisma.$TagPayload<ExtArgs>,
+        T,
+        'findUniqueOrThrow',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -7655,9 +8726,15 @@ export namespace Prisma {
     findFirst<T extends TagFindFirstArgs>(
       args?: SelectSubset<T, TagFindFirstArgs<ExtArgs>>,
     ): Prisma__TagClient<
-      $Result.GetResult<Prisma.$TagPayload<ExtArgs>, T, 'findFirst'> | null,
+      $Result.GetResult<
+        Prisma.$TagPayload<ExtArgs>,
+        T,
+        'findFirst',
+        ClientOptions
+      > | null,
       null,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -7677,9 +8754,15 @@ export namespace Prisma {
     findFirstOrThrow<T extends TagFindFirstOrThrowArgs>(
       args?: SelectSubset<T, TagFindFirstOrThrowArgs<ExtArgs>>,
     ): Prisma__TagClient<
-      $Result.GetResult<Prisma.$TagPayload<ExtArgs>, T, 'findFirstOrThrow'>,
+      $Result.GetResult<
+        Prisma.$TagPayload<ExtArgs>,
+        T,
+        'findFirstOrThrow',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -7701,7 +8784,12 @@ export namespace Prisma {
     findMany<T extends TagFindManyArgs>(
       args?: SelectSubset<T, TagFindManyArgs<ExtArgs>>,
     ): Prisma.PrismaPromise<
-      $Result.GetResult<Prisma.$TagPayload<ExtArgs>, T, 'findMany'>
+      $Result.GetResult<
+        Prisma.$TagPayload<ExtArgs>,
+        T,
+        'findMany',
+        ClientOptions
+      >
     >;
 
     /**
@@ -7719,9 +8807,15 @@ export namespace Prisma {
     create<T extends TagCreateArgs>(
       args: SelectSubset<T, TagCreateArgs<ExtArgs>>,
     ): Prisma__TagClient<
-      $Result.GetResult<Prisma.$TagPayload<ExtArgs>, T, 'create'>,
+      $Result.GetResult<
+        Prisma.$TagPayload<ExtArgs>,
+        T,
+        'create',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -7765,7 +8859,12 @@ export namespace Prisma {
     createManyAndReturn<T extends TagCreateManyAndReturnArgs>(
       args?: SelectSubset<T, TagCreateManyAndReturnArgs<ExtArgs>>,
     ): Prisma.PrismaPromise<
-      $Result.GetResult<Prisma.$TagPayload<ExtArgs>, T, 'createManyAndReturn'>
+      $Result.GetResult<
+        Prisma.$TagPayload<ExtArgs>,
+        T,
+        'createManyAndReturn',
+        ClientOptions
+      >
     >;
 
     /**
@@ -7783,9 +8882,15 @@ export namespace Prisma {
     delete<T extends TagDeleteArgs>(
       args: SelectSubset<T, TagDeleteArgs<ExtArgs>>,
     ): Prisma__TagClient<
-      $Result.GetResult<Prisma.$TagPayload<ExtArgs>, T, 'delete'>,
+      $Result.GetResult<
+        Prisma.$TagPayload<ExtArgs>,
+        T,
+        'delete',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -7806,9 +8911,15 @@ export namespace Prisma {
     update<T extends TagUpdateArgs>(
       args: SelectSubset<T, TagUpdateArgs<ExtArgs>>,
     ): Prisma__TagClient<
-      $Result.GetResult<Prisma.$TagPayload<ExtArgs>, T, 'update'>,
+      $Result.GetResult<
+        Prisma.$TagPayload<ExtArgs>,
+        T,
+        'update',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -7849,6 +8960,45 @@ export namespace Prisma {
     ): Prisma.PrismaPromise<BatchPayload>;
 
     /**
+     * Update zero or more Tags and returns the data updated in the database.
+     * @param {TagUpdateManyAndReturnArgs} args - Arguments to update many Tags.
+     * @example
+     * // Update many Tags
+     * const tag = await prisma.tag.updateManyAndReturn({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: [
+     *     // ... provide data here
+     *   ]
+     * })
+     *
+     * // Update zero or more Tags and only return the `id`
+     * const tagWithIdOnly = await prisma.tag.updateManyAndReturn({
+     *   select: { id: true },
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: [
+     *     // ... provide data here
+     *   ]
+     * })
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     *
+     */
+    updateManyAndReturn<T extends TagUpdateManyAndReturnArgs>(
+      args: SelectSubset<T, TagUpdateManyAndReturnArgs<ExtArgs>>,
+    ): Prisma.PrismaPromise<
+      $Result.GetResult<
+        Prisma.$TagPayload<ExtArgs>,
+        T,
+        'updateManyAndReturn',
+        ClientOptions
+      >
+    >;
+
+    /**
      * Create or update one Tag.
      * @param {TagUpsertArgs} args - Arguments to update or create a Tag.
      * @example
@@ -7868,9 +9018,15 @@ export namespace Prisma {
     upsert<T extends TagUpsertArgs>(
       args: SelectSubset<T, TagUpsertArgs<ExtArgs>>,
     ): Prisma__TagClient<
-      $Result.GetResult<Prisma.$TagPayload<ExtArgs>, T, 'upsert'>,
+      $Result.GetResult<
+        Prisma.$TagPayload<ExtArgs>,
+        T,
+        'upsert',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -8022,6 +9178,7 @@ export namespace Prisma {
     T,
     Null = never,
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+    ClientOptions = {},
   > extends Prisma.PrismaPromise<T> {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     group<T extends TagGroupDefaultArgs<ExtArgs> = {}>(
@@ -8030,11 +9187,13 @@ export namespace Prisma {
       | $Result.GetResult<
           Prisma.$TagGroupPayload<ExtArgs>,
           T,
-          'findUniqueOrThrow'
+          'findUniqueOrThrow',
+          ClientOptions
         >
       | Null,
       Null,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
     assistedEvent<T extends Tag$assistedEventArgs<ExtArgs> = {}>(
       args?: Subset<T, Tag$assistedEventArgs<ExtArgs>>,
@@ -8042,10 +9201,12 @@ export namespace Prisma {
       $Result.GetResult<
         Prisma.$EventPayload<ExtArgs>,
         T,
-        'findUniqueOrThrow'
+        'findUniqueOrThrow',
+        ClientOptions
       > | null,
       null,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
     confirmedEvent<T extends Tag$confirmedEventArgs<ExtArgs> = {}>(
       args?: Subset<T, Tag$confirmedEventArgs<ExtArgs>>,
@@ -8053,25 +9214,45 @@ export namespace Prisma {
       $Result.GetResult<
         Prisma.$EventPayload<ExtArgs>,
         T,
-        'findUniqueOrThrow'
+        'findUniqueOrThrow',
+        ClientOptions
       > | null,
       null,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
     accounts<T extends Tag$accountsArgs<ExtArgs> = {}>(
       args?: Subset<T, Tag$accountsArgs<ExtArgs>>,
     ): Prisma.PrismaPromise<
-      $Result.GetResult<Prisma.$AccountPayload<ExtArgs>, T, 'findMany'> | Null
+      | $Result.GetResult<
+          Prisma.$AccountPayload<ExtArgs>,
+          T,
+          'findMany',
+          ClientOptions
+        >
+      | Null
     >;
     profiles<T extends Tag$profilesArgs<ExtArgs> = {}>(
       args?: Subset<T, Tag$profilesArgs<ExtArgs>>,
     ): Prisma.PrismaPromise<
-      $Result.GetResult<Prisma.$ProfilePayload<ExtArgs>, T, 'findMany'> | Null
+      | $Result.GetResult<
+          Prisma.$ProfilePayload<ExtArgs>,
+          T,
+          'findMany',
+          ClientOptions
+        >
+      | Null
     >;
     accountsGlobalFilter<T extends Tag$accountsGlobalFilterArgs<ExtArgs> = {}>(
       args?: Subset<T, Tag$accountsGlobalFilterArgs<ExtArgs>>,
     ): Prisma.PrismaPromise<
-      $Result.GetResult<Prisma.$AccountPayload<ExtArgs>, T, 'findMany'> | Null
+      | $Result.GetResult<
+          Prisma.$AccountPayload<ExtArgs>,
+          T,
+          'findMany',
+          ClientOptions
+        >
+      | Null
     >;
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
@@ -8133,6 +9314,10 @@ export namespace Prisma {
      */
     select?: TagSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Tag
+     */
+    omit?: TagOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: TagInclude<ExtArgs> | null;
@@ -8153,6 +9338,10 @@ export namespace Prisma {
      */
     select?: TagSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Tag
+     */
+    omit?: TagOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: TagInclude<ExtArgs> | null;
@@ -8172,6 +9361,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the Tag
      */
     select?: TagSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Tag
+     */
+    omit?: TagOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -8223,6 +9416,10 @@ export namespace Prisma {
      */
     select?: TagSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Tag
+     */
+    omit?: TagOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: TagInclude<ExtArgs> | null;
@@ -8273,6 +9470,10 @@ export namespace Prisma {
      */
     select?: TagSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Tag
+     */
+    omit?: TagOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: TagInclude<ExtArgs> | null;
@@ -8318,6 +9519,10 @@ export namespace Prisma {
      */
     select?: TagSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Tag
+     */
+    omit?: TagOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: TagInclude<ExtArgs> | null;
@@ -8351,6 +9556,10 @@ export namespace Prisma {
      */
     select?: TagSelectCreateManyAndReturn<ExtArgs> | null;
     /**
+     * Omit specific fields from the Tag
+     */
+    omit?: TagOmit<ExtArgs> | null;
+    /**
      * The data used to create many Tags.
      */
     data: TagCreateManyInput | TagCreateManyInput[];
@@ -8371,6 +9580,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the Tag
      */
     select?: TagSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Tag
+     */
+    omit?: TagOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -8399,6 +9612,42 @@ export namespace Prisma {
      * Filter which Tags to update
      */
     where?: TagWhereInput;
+    /**
+     * Limit how many Tags to update.
+     */
+    limit?: number;
+  };
+
+  /**
+   * Tag updateManyAndReturn
+   */
+  export type TagUpdateManyAndReturnArgs<
+    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  > = {
+    /**
+     * Select specific fields to fetch from the Tag
+     */
+    select?: TagSelectUpdateManyAndReturn<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Tag
+     */
+    omit?: TagOmit<ExtArgs> | null;
+    /**
+     * The data used to update Tags.
+     */
+    data: XOR<TagUpdateManyMutationInput, TagUncheckedUpdateManyInput>;
+    /**
+     * Filter which Tags to update
+     */
+    where?: TagWhereInput;
+    /**
+     * Limit how many Tags to update.
+     */
+    limit?: number;
+    /**
+     * Choose, which related nodes to fetch as well
+     */
+    include?: TagIncludeUpdateManyAndReturn<ExtArgs> | null;
   };
 
   /**
@@ -8411,6 +9660,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the Tag
      */
     select?: TagSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Tag
+     */
+    omit?: TagOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -8440,6 +9693,10 @@ export namespace Prisma {
      */
     select?: TagSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Tag
+     */
+    omit?: TagOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: TagInclude<ExtArgs> | null;
@@ -8459,6 +9716,10 @@ export namespace Prisma {
      * Filter which Tags to delete
      */
     where?: TagWhereInput;
+    /**
+     * Limit how many Tags to delete.
+     */
+    limit?: number;
   };
 
   /**
@@ -8471,6 +9732,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the Event
      */
     select?: EventSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Event
+     */
+    omit?: EventOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -8489,6 +9754,10 @@ export namespace Prisma {
      */
     select?: EventSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Event
+     */
+    omit?: EventOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: EventInclude<ExtArgs> | null;
@@ -8505,6 +9774,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the Account
      */
     select?: AccountSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Account
+     */
+    omit?: AccountOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -8530,6 +9803,10 @@ export namespace Prisma {
      */
     select?: ProfileSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Profile
+     */
+    omit?: ProfileOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: ProfileInclude<ExtArgs> | null;
@@ -8554,6 +9831,10 @@ export namespace Prisma {
      */
     select?: AccountSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Account
+     */
+    omit?: AccountOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: AccountInclude<ExtArgs> | null;
@@ -8577,6 +9858,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the Tag
      */
     select?: TagSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Tag
+     */
+    omit?: TagOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -8781,6 +10066,20 @@ export namespace Prisma {
     ExtArgs['result']['tagGroup']
   >;
 
+  export type TagGroupSelectUpdateManyAndReturn<
+    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  > = $Extensions.GetSelect<
+    {
+      id?: boolean;
+      name?: boolean;
+      color?: boolean;
+      isExclusive?: boolean;
+      created_at?: boolean;
+      updated_at?: boolean;
+    },
+    ExtArgs['result']['tagGroup']
+  >;
+
   export type TagGroupSelectScalar = {
     id?: boolean;
     name?: boolean;
@@ -8790,6 +10089,12 @@ export namespace Prisma {
     updated_at?: boolean;
   };
 
+  export type TagGroupOmit<
+    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  > = $Extensions.GetOmit<
+    'id' | 'name' | 'color' | 'isExclusive' | 'created_at' | 'updated_at',
+    ExtArgs['result']['tagGroup']
+  >;
   export type TagGroupInclude<
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
   > = {
@@ -8797,6 +10102,9 @@ export namespace Prisma {
     _count?: boolean | TagGroupCountOutputTypeDefaultArgs<ExtArgs>;
   };
   export type TagGroupIncludeCreateManyAndReturn<
+    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  > = {};
+  export type TagGroupIncludeUpdateManyAndReturn<
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
   > = {};
 
@@ -8827,12 +10135,13 @@ export namespace Prisma {
 
   type TagGroupCountArgs<
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
-  > = Omit<TagGroupFindManyArgs, 'select' | 'include' | 'distinct'> & {
+  > = Omit<TagGroupFindManyArgs, 'select' | 'include' | 'distinct' | 'omit'> & {
     select?: TagGroupCountAggregateInputType | true;
   };
 
   export interface TagGroupDelegate<
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+    ClientOptions = {},
   > {
     [K: symbol]: {
       types: Prisma.TypeMap<ExtArgs>['model']['TagGroup'];
@@ -8855,10 +10164,12 @@ export namespace Prisma {
       $Result.GetResult<
         Prisma.$TagGroupPayload<ExtArgs>,
         T,
-        'findUnique'
+        'findUnique',
+        ClientOptions
       > | null,
       null,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -8879,10 +10190,12 @@ export namespace Prisma {
       $Result.GetResult<
         Prisma.$TagGroupPayload<ExtArgs>,
         T,
-        'findUniqueOrThrow'
+        'findUniqueOrThrow',
+        ClientOptions
       >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -8904,10 +10217,12 @@ export namespace Prisma {
       $Result.GetResult<
         Prisma.$TagGroupPayload<ExtArgs>,
         T,
-        'findFirst'
+        'findFirst',
+        ClientOptions
       > | null,
       null,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -8930,10 +10245,12 @@ export namespace Prisma {
       $Result.GetResult<
         Prisma.$TagGroupPayload<ExtArgs>,
         T,
-        'findFirstOrThrow'
+        'findFirstOrThrow',
+        ClientOptions
       >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -8955,7 +10272,12 @@ export namespace Prisma {
     findMany<T extends TagGroupFindManyArgs>(
       args?: SelectSubset<T, TagGroupFindManyArgs<ExtArgs>>,
     ): Prisma.PrismaPromise<
-      $Result.GetResult<Prisma.$TagGroupPayload<ExtArgs>, T, 'findMany'>
+      $Result.GetResult<
+        Prisma.$TagGroupPayload<ExtArgs>,
+        T,
+        'findMany',
+        ClientOptions
+      >
     >;
 
     /**
@@ -8973,9 +10295,15 @@ export namespace Prisma {
     create<T extends TagGroupCreateArgs>(
       args: SelectSubset<T, TagGroupCreateArgs<ExtArgs>>,
     ): Prisma__TagGroupClient<
-      $Result.GetResult<Prisma.$TagGroupPayload<ExtArgs>, T, 'create'>,
+      $Result.GetResult<
+        Prisma.$TagGroupPayload<ExtArgs>,
+        T,
+        'create',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -9022,7 +10350,8 @@ export namespace Prisma {
       $Result.GetResult<
         Prisma.$TagGroupPayload<ExtArgs>,
         T,
-        'createManyAndReturn'
+        'createManyAndReturn',
+        ClientOptions
       >
     >;
 
@@ -9041,9 +10370,15 @@ export namespace Prisma {
     delete<T extends TagGroupDeleteArgs>(
       args: SelectSubset<T, TagGroupDeleteArgs<ExtArgs>>,
     ): Prisma__TagGroupClient<
-      $Result.GetResult<Prisma.$TagGroupPayload<ExtArgs>, T, 'delete'>,
+      $Result.GetResult<
+        Prisma.$TagGroupPayload<ExtArgs>,
+        T,
+        'delete',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -9064,9 +10399,15 @@ export namespace Prisma {
     update<T extends TagGroupUpdateArgs>(
       args: SelectSubset<T, TagGroupUpdateArgs<ExtArgs>>,
     ): Prisma__TagGroupClient<
-      $Result.GetResult<Prisma.$TagGroupPayload<ExtArgs>, T, 'update'>,
+      $Result.GetResult<
+        Prisma.$TagGroupPayload<ExtArgs>,
+        T,
+        'update',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -9107,6 +10448,45 @@ export namespace Prisma {
     ): Prisma.PrismaPromise<BatchPayload>;
 
     /**
+     * Update zero or more TagGroups and returns the data updated in the database.
+     * @param {TagGroupUpdateManyAndReturnArgs} args - Arguments to update many TagGroups.
+     * @example
+     * // Update many TagGroups
+     * const tagGroup = await prisma.tagGroup.updateManyAndReturn({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: [
+     *     // ... provide data here
+     *   ]
+     * })
+     *
+     * // Update zero or more TagGroups and only return the `id`
+     * const tagGroupWithIdOnly = await prisma.tagGroup.updateManyAndReturn({
+     *   select: { id: true },
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: [
+     *     // ... provide data here
+     *   ]
+     * })
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     *
+     */
+    updateManyAndReturn<T extends TagGroupUpdateManyAndReturnArgs>(
+      args: SelectSubset<T, TagGroupUpdateManyAndReturnArgs<ExtArgs>>,
+    ): Prisma.PrismaPromise<
+      $Result.GetResult<
+        Prisma.$TagGroupPayload<ExtArgs>,
+        T,
+        'updateManyAndReturn',
+        ClientOptions
+      >
+    >;
+
+    /**
      * Create or update one TagGroup.
      * @param {TagGroupUpsertArgs} args - Arguments to update or create a TagGroup.
      * @example
@@ -9126,9 +10506,15 @@ export namespace Prisma {
     upsert<T extends TagGroupUpsertArgs>(
       args: SelectSubset<T, TagGroupUpsertArgs<ExtArgs>>,
     ): Prisma__TagGroupClient<
-      $Result.GetResult<Prisma.$TagGroupPayload<ExtArgs>, T, 'upsert'>,
+      $Result.GetResult<
+        Prisma.$TagGroupPayload<ExtArgs>,
+        T,
+        'upsert',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -9281,12 +10667,19 @@ export namespace Prisma {
     T,
     Null = never,
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+    ClientOptions = {},
   > extends Prisma.PrismaPromise<T> {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     tags<T extends TagGroup$tagsArgs<ExtArgs> = {}>(
       args?: Subset<T, TagGroup$tagsArgs<ExtArgs>>,
     ): Prisma.PrismaPromise<
-      $Result.GetResult<Prisma.$TagPayload<ExtArgs>, T, 'findMany'> | Null
+      | $Result.GetResult<
+          Prisma.$TagPayload<ExtArgs>,
+          T,
+          'findMany',
+          ClientOptions
+        >
+      | Null
     >;
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
@@ -9348,6 +10741,10 @@ export namespace Prisma {
      */
     select?: TagGroupSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the TagGroup
+     */
+    omit?: TagGroupOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: TagGroupInclude<ExtArgs> | null;
@@ -9368,6 +10765,10 @@ export namespace Prisma {
      */
     select?: TagGroupSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the TagGroup
+     */
+    omit?: TagGroupOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: TagGroupInclude<ExtArgs> | null;
@@ -9387,6 +10788,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the TagGroup
      */
     select?: TagGroupSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the TagGroup
+     */
+    omit?: TagGroupOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -9440,6 +10845,10 @@ export namespace Prisma {
      */
     select?: TagGroupSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the TagGroup
+     */
+    omit?: TagGroupOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: TagGroupInclude<ExtArgs> | null;
@@ -9492,6 +10901,10 @@ export namespace Prisma {
      */
     select?: TagGroupSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the TagGroup
+     */
+    omit?: TagGroupOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: TagGroupInclude<ExtArgs> | null;
@@ -9539,6 +10952,10 @@ export namespace Prisma {
      */
     select?: TagGroupSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the TagGroup
+     */
+    omit?: TagGroupOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: TagGroupInclude<ExtArgs> | null;
@@ -9572,6 +10989,10 @@ export namespace Prisma {
      */
     select?: TagGroupSelectCreateManyAndReturn<ExtArgs> | null;
     /**
+     * Omit specific fields from the TagGroup
+     */
+    omit?: TagGroupOmit<ExtArgs> | null;
+    /**
      * The data used to create many TagGroups.
      */
     data: TagGroupCreateManyInput | TagGroupCreateManyInput[];
@@ -9588,6 +11009,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the TagGroup
      */
     select?: TagGroupSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the TagGroup
+     */
+    omit?: TagGroupOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -9619,6 +11044,41 @@ export namespace Prisma {
      * Filter which TagGroups to update
      */
     where?: TagGroupWhereInput;
+    /**
+     * Limit how many TagGroups to update.
+     */
+    limit?: number;
+  };
+
+  /**
+   * TagGroup updateManyAndReturn
+   */
+  export type TagGroupUpdateManyAndReturnArgs<
+    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  > = {
+    /**
+     * Select specific fields to fetch from the TagGroup
+     */
+    select?: TagGroupSelectUpdateManyAndReturn<ExtArgs> | null;
+    /**
+     * Omit specific fields from the TagGroup
+     */
+    omit?: TagGroupOmit<ExtArgs> | null;
+    /**
+     * The data used to update TagGroups.
+     */
+    data: XOR<
+      TagGroupUpdateManyMutationInput,
+      TagGroupUncheckedUpdateManyInput
+    >;
+    /**
+     * Filter which TagGroups to update
+     */
+    where?: TagGroupWhereInput;
+    /**
+     * Limit how many TagGroups to update.
+     */
+    limit?: number;
   };
 
   /**
@@ -9631,6 +11091,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the TagGroup
      */
     select?: TagGroupSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the TagGroup
+     */
+    omit?: TagGroupOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -9660,6 +11124,10 @@ export namespace Prisma {
      */
     select?: TagGroupSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the TagGroup
+     */
+    omit?: TagGroupOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: TagGroupInclude<ExtArgs> | null;
@@ -9679,6 +11147,10 @@ export namespace Prisma {
      * Filter which TagGroups to delete
      */
     where?: TagGroupWhereInput;
+    /**
+     * Limit how many TagGroups to delete.
+     */
+    limit?: number;
   };
 
   /**
@@ -9691,6 +11163,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the Tag
      */
     select?: TagSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Tag
+     */
+    omit?: TagOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -9713,6 +11189,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the TagGroup
      */
     select?: TagGroupSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the TagGroup
+     */
+    omit?: TagGroupOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -9959,6 +11439,28 @@ export namespace Prisma {
     ExtArgs['result']['event']
   >;
 
+  export type EventSelectUpdateManyAndReturn<
+    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  > = $Extensions.GetSelect<
+    {
+      id?: boolean;
+      name?: boolean;
+      date?: boolean;
+      location?: boolean;
+      folderId?: boolean;
+      tagAssistedId?: boolean;
+      tagConfirmedId?: boolean;
+      supraEventId?: boolean;
+      created_at?: boolean;
+      updated_at?: boolean;
+      folder?: boolean | Event$folderArgs<ExtArgs>;
+      tagAssisted?: boolean | TagDefaultArgs<ExtArgs>;
+      tagConfirmed?: boolean | TagDefaultArgs<ExtArgs>;
+      supraEvent?: boolean | Event$supraEventArgs<ExtArgs>;
+    },
+    ExtArgs['result']['event']
+  >;
+
   export type EventSelectScalar = {
     id?: boolean;
     name?: boolean;
@@ -9972,6 +11474,21 @@ export namespace Prisma {
     updated_at?: boolean;
   };
 
+  export type EventOmit<
+    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  > = $Extensions.GetOmit<
+    | 'id'
+    | 'name'
+    | 'date'
+    | 'location'
+    | 'folderId'
+    | 'tagAssistedId'
+    | 'tagConfirmedId'
+    | 'supraEventId'
+    | 'created_at'
+    | 'updated_at',
+    ExtArgs['result']['event']
+  >;
   export type EventInclude<
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
   > = {
@@ -9983,6 +11500,14 @@ export namespace Prisma {
     _count?: boolean | EventCountOutputTypeDefaultArgs<ExtArgs>;
   };
   export type EventIncludeCreateManyAndReturn<
+    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  > = {
+    folder?: boolean | Event$folderArgs<ExtArgs>;
+    tagAssisted?: boolean | TagDefaultArgs<ExtArgs>;
+    tagConfirmed?: boolean | TagDefaultArgs<ExtArgs>;
+    supraEvent?: boolean | Event$supraEventArgs<ExtArgs>;
+  };
+  export type EventIncludeUpdateManyAndReturn<
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
   > = {
     folder?: boolean | Event$folderArgs<ExtArgs>;
@@ -10026,12 +11551,13 @@ export namespace Prisma {
 
   type EventCountArgs<
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
-  > = Omit<EventFindManyArgs, 'select' | 'include' | 'distinct'> & {
+  > = Omit<EventFindManyArgs, 'select' | 'include' | 'distinct' | 'omit'> & {
     select?: EventCountAggregateInputType | true;
   };
 
   export interface EventDelegate<
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+    ClientOptions = {},
   > {
     [K: symbol]: {
       types: Prisma.TypeMap<ExtArgs>['model']['Event'];
@@ -10051,9 +11577,15 @@ export namespace Prisma {
     findUnique<T extends EventFindUniqueArgs>(
       args: SelectSubset<T, EventFindUniqueArgs<ExtArgs>>,
     ): Prisma__EventClient<
-      $Result.GetResult<Prisma.$EventPayload<ExtArgs>, T, 'findUnique'> | null,
+      $Result.GetResult<
+        Prisma.$EventPayload<ExtArgs>,
+        T,
+        'findUnique',
+        ClientOptions
+      > | null,
       null,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -10071,9 +11603,15 @@ export namespace Prisma {
     findUniqueOrThrow<T extends EventFindUniqueOrThrowArgs>(
       args: SelectSubset<T, EventFindUniqueOrThrowArgs<ExtArgs>>,
     ): Prisma__EventClient<
-      $Result.GetResult<Prisma.$EventPayload<ExtArgs>, T, 'findUniqueOrThrow'>,
+      $Result.GetResult<
+        Prisma.$EventPayload<ExtArgs>,
+        T,
+        'findUniqueOrThrow',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -10092,9 +11630,15 @@ export namespace Prisma {
     findFirst<T extends EventFindFirstArgs>(
       args?: SelectSubset<T, EventFindFirstArgs<ExtArgs>>,
     ): Prisma__EventClient<
-      $Result.GetResult<Prisma.$EventPayload<ExtArgs>, T, 'findFirst'> | null,
+      $Result.GetResult<
+        Prisma.$EventPayload<ExtArgs>,
+        T,
+        'findFirst',
+        ClientOptions
+      > | null,
       null,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -10114,9 +11658,15 @@ export namespace Prisma {
     findFirstOrThrow<T extends EventFindFirstOrThrowArgs>(
       args?: SelectSubset<T, EventFindFirstOrThrowArgs<ExtArgs>>,
     ): Prisma__EventClient<
-      $Result.GetResult<Prisma.$EventPayload<ExtArgs>, T, 'findFirstOrThrow'>,
+      $Result.GetResult<
+        Prisma.$EventPayload<ExtArgs>,
+        T,
+        'findFirstOrThrow',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -10138,7 +11688,12 @@ export namespace Prisma {
     findMany<T extends EventFindManyArgs>(
       args?: SelectSubset<T, EventFindManyArgs<ExtArgs>>,
     ): Prisma.PrismaPromise<
-      $Result.GetResult<Prisma.$EventPayload<ExtArgs>, T, 'findMany'>
+      $Result.GetResult<
+        Prisma.$EventPayload<ExtArgs>,
+        T,
+        'findMany',
+        ClientOptions
+      >
     >;
 
     /**
@@ -10156,9 +11711,15 @@ export namespace Prisma {
     create<T extends EventCreateArgs>(
       args: SelectSubset<T, EventCreateArgs<ExtArgs>>,
     ): Prisma__EventClient<
-      $Result.GetResult<Prisma.$EventPayload<ExtArgs>, T, 'create'>,
+      $Result.GetResult<
+        Prisma.$EventPayload<ExtArgs>,
+        T,
+        'create',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -10202,7 +11763,12 @@ export namespace Prisma {
     createManyAndReturn<T extends EventCreateManyAndReturnArgs>(
       args?: SelectSubset<T, EventCreateManyAndReturnArgs<ExtArgs>>,
     ): Prisma.PrismaPromise<
-      $Result.GetResult<Prisma.$EventPayload<ExtArgs>, T, 'createManyAndReturn'>
+      $Result.GetResult<
+        Prisma.$EventPayload<ExtArgs>,
+        T,
+        'createManyAndReturn',
+        ClientOptions
+      >
     >;
 
     /**
@@ -10220,9 +11786,15 @@ export namespace Prisma {
     delete<T extends EventDeleteArgs>(
       args: SelectSubset<T, EventDeleteArgs<ExtArgs>>,
     ): Prisma__EventClient<
-      $Result.GetResult<Prisma.$EventPayload<ExtArgs>, T, 'delete'>,
+      $Result.GetResult<
+        Prisma.$EventPayload<ExtArgs>,
+        T,
+        'delete',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -10243,9 +11815,15 @@ export namespace Prisma {
     update<T extends EventUpdateArgs>(
       args: SelectSubset<T, EventUpdateArgs<ExtArgs>>,
     ): Prisma__EventClient<
-      $Result.GetResult<Prisma.$EventPayload<ExtArgs>, T, 'update'>,
+      $Result.GetResult<
+        Prisma.$EventPayload<ExtArgs>,
+        T,
+        'update',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -10286,6 +11864,45 @@ export namespace Prisma {
     ): Prisma.PrismaPromise<BatchPayload>;
 
     /**
+     * Update zero or more Events and returns the data updated in the database.
+     * @param {EventUpdateManyAndReturnArgs} args - Arguments to update many Events.
+     * @example
+     * // Update many Events
+     * const event = await prisma.event.updateManyAndReturn({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: [
+     *     // ... provide data here
+     *   ]
+     * })
+     *
+     * // Update zero or more Events and only return the `id`
+     * const eventWithIdOnly = await prisma.event.updateManyAndReturn({
+     *   select: { id: true },
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: [
+     *     // ... provide data here
+     *   ]
+     * })
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     *
+     */
+    updateManyAndReturn<T extends EventUpdateManyAndReturnArgs>(
+      args: SelectSubset<T, EventUpdateManyAndReturnArgs<ExtArgs>>,
+    ): Prisma.PrismaPromise<
+      $Result.GetResult<
+        Prisma.$EventPayload<ExtArgs>,
+        T,
+        'updateManyAndReturn',
+        ClientOptions
+      >
+    >;
+
+    /**
      * Create or update one Event.
      * @param {EventUpsertArgs} args - Arguments to update or create a Event.
      * @example
@@ -10305,9 +11922,15 @@ export namespace Prisma {
     upsert<T extends EventUpsertArgs>(
       args: SelectSubset<T, EventUpsertArgs<ExtArgs>>,
     ): Prisma__EventClient<
-      $Result.GetResult<Prisma.$EventPayload<ExtArgs>, T, 'upsert'>,
+      $Result.GetResult<
+        Prisma.$EventPayload<ExtArgs>,
+        T,
+        'upsert',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -10459,6 +12082,7 @@ export namespace Prisma {
     T,
     Null = never,
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+    ClientOptions = {},
   > extends Prisma.PrismaPromise<T> {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     folder<T extends Event$folderArgs<ExtArgs> = {}>(
@@ -10467,26 +12091,40 @@ export namespace Prisma {
       $Result.GetResult<
         Prisma.$EventFolderPayload<ExtArgs>,
         T,
-        'findUniqueOrThrow'
+        'findUniqueOrThrow',
+        ClientOptions
       > | null,
       null,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
     tagAssisted<T extends TagDefaultArgs<ExtArgs> = {}>(
       args?: Subset<T, TagDefaultArgs<ExtArgs>>,
     ): Prisma__TagClient<
-      | $Result.GetResult<Prisma.$TagPayload<ExtArgs>, T, 'findUniqueOrThrow'>
+      | $Result.GetResult<
+          Prisma.$TagPayload<ExtArgs>,
+          T,
+          'findUniqueOrThrow',
+          ClientOptions
+        >
       | Null,
       Null,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
     tagConfirmed<T extends TagDefaultArgs<ExtArgs> = {}>(
       args?: Subset<T, TagDefaultArgs<ExtArgs>>,
     ): Prisma__TagClient<
-      | $Result.GetResult<Prisma.$TagPayload<ExtArgs>, T, 'findUniqueOrThrow'>
+      | $Result.GetResult<
+          Prisma.$TagPayload<ExtArgs>,
+          T,
+          'findUniqueOrThrow',
+          ClientOptions
+        >
       | Null,
       Null,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
     supraEvent<T extends Event$supraEventArgs<ExtArgs> = {}>(
       args?: Subset<T, Event$supraEventArgs<ExtArgs>>,
@@ -10494,15 +12132,23 @@ export namespace Prisma {
       $Result.GetResult<
         Prisma.$EventPayload<ExtArgs>,
         T,
-        'findUniqueOrThrow'
+        'findUniqueOrThrow',
+        ClientOptions
       > | null,
       null,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
     subEvents<T extends Event$subEventsArgs<ExtArgs> = {}>(
       args?: Subset<T, Event$subEventsArgs<ExtArgs>>,
     ): Prisma.PrismaPromise<
-      $Result.GetResult<Prisma.$EventPayload<ExtArgs>, T, 'findMany'> | Null
+      | $Result.GetResult<
+          Prisma.$EventPayload<ExtArgs>,
+          T,
+          'findMany',
+          ClientOptions
+        >
+      | Null
     >;
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
@@ -10568,6 +12214,10 @@ export namespace Prisma {
      */
     select?: EventSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Event
+     */
+    omit?: EventOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: EventInclude<ExtArgs> | null;
@@ -10588,6 +12238,10 @@ export namespace Prisma {
      */
     select?: EventSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Event
+     */
+    omit?: EventOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: EventInclude<ExtArgs> | null;
@@ -10607,6 +12261,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the Event
      */
     select?: EventSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Event
+     */
+    omit?: EventOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -10658,6 +12316,10 @@ export namespace Prisma {
      */
     select?: EventSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Event
+     */
+    omit?: EventOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: EventInclude<ExtArgs> | null;
@@ -10708,6 +12370,10 @@ export namespace Prisma {
      */
     select?: EventSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Event
+     */
+    omit?: EventOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: EventInclude<ExtArgs> | null;
@@ -10753,6 +12419,10 @@ export namespace Prisma {
      */
     select?: EventSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Event
+     */
+    omit?: EventOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: EventInclude<ExtArgs> | null;
@@ -10786,6 +12456,10 @@ export namespace Prisma {
      */
     select?: EventSelectCreateManyAndReturn<ExtArgs> | null;
     /**
+     * Omit specific fields from the Event
+     */
+    omit?: EventOmit<ExtArgs> | null;
+    /**
      * The data used to create many Events.
      */
     data: EventCreateManyInput | EventCreateManyInput[];
@@ -10806,6 +12480,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the Event
      */
     select?: EventSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Event
+     */
+    omit?: EventOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -10834,6 +12512,42 @@ export namespace Prisma {
      * Filter which Events to update
      */
     where?: EventWhereInput;
+    /**
+     * Limit how many Events to update.
+     */
+    limit?: number;
+  };
+
+  /**
+   * Event updateManyAndReturn
+   */
+  export type EventUpdateManyAndReturnArgs<
+    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  > = {
+    /**
+     * Select specific fields to fetch from the Event
+     */
+    select?: EventSelectUpdateManyAndReturn<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Event
+     */
+    omit?: EventOmit<ExtArgs> | null;
+    /**
+     * The data used to update Events.
+     */
+    data: XOR<EventUpdateManyMutationInput, EventUncheckedUpdateManyInput>;
+    /**
+     * Filter which Events to update
+     */
+    where?: EventWhereInput;
+    /**
+     * Limit how many Events to update.
+     */
+    limit?: number;
+    /**
+     * Choose, which related nodes to fetch as well
+     */
+    include?: EventIncludeUpdateManyAndReturn<ExtArgs> | null;
   };
 
   /**
@@ -10846,6 +12560,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the Event
      */
     select?: EventSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Event
+     */
+    omit?: EventOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -10875,6 +12593,10 @@ export namespace Prisma {
      */
     select?: EventSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Event
+     */
+    omit?: EventOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: EventInclude<ExtArgs> | null;
@@ -10894,6 +12616,10 @@ export namespace Prisma {
      * Filter which Events to delete
      */
     where?: EventWhereInput;
+    /**
+     * Limit how many Events to delete.
+     */
+    limit?: number;
   };
 
   /**
@@ -10906,6 +12632,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the EventFolder
      */
     select?: EventFolderSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the EventFolder
+     */
+    omit?: EventFolderOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -10924,6 +12654,10 @@ export namespace Prisma {
      */
     select?: EventSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Event
+     */
+    omit?: EventOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: EventInclude<ExtArgs> | null;
@@ -10940,6 +12674,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the Event
      */
     select?: EventSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Event
+     */
+    omit?: EventOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -10962,6 +12700,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the Event
      */
     select?: EventSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Event
+     */
+    omit?: EventOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -11159,6 +12901,19 @@ export namespace Prisma {
     ExtArgs['result']['eventFolder']
   >;
 
+  export type EventFolderSelectUpdateManyAndReturn<
+    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  > = $Extensions.GetSelect<
+    {
+      id?: boolean;
+      name?: boolean;
+      color?: boolean;
+      created_at?: boolean;
+      updated_at?: boolean;
+    },
+    ExtArgs['result']['eventFolder']
+  >;
+
   export type EventFolderSelectScalar = {
     id?: boolean;
     name?: boolean;
@@ -11167,6 +12922,12 @@ export namespace Prisma {
     updated_at?: boolean;
   };
 
+  export type EventFolderOmit<
+    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  > = $Extensions.GetOmit<
+    'id' | 'name' | 'color' | 'created_at' | 'updated_at',
+    ExtArgs['result']['eventFolder']
+  >;
   export type EventFolderInclude<
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
   > = {
@@ -11174,6 +12935,9 @@ export namespace Prisma {
     _count?: boolean | EventFolderCountOutputTypeDefaultArgs<ExtArgs>;
   };
   export type EventFolderIncludeCreateManyAndReturn<
+    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  > = {};
+  export type EventFolderIncludeUpdateManyAndReturn<
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
   > = {};
 
@@ -11203,12 +12967,16 @@ export namespace Prisma {
 
   type EventFolderCountArgs<
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
-  > = Omit<EventFolderFindManyArgs, 'select' | 'include' | 'distinct'> & {
+  > = Omit<
+    EventFolderFindManyArgs,
+    'select' | 'include' | 'distinct' | 'omit'
+  > & {
     select?: EventFolderCountAggregateInputType | true;
   };
 
   export interface EventFolderDelegate<
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+    ClientOptions = {},
   > {
     [K: symbol]: {
       types: Prisma.TypeMap<ExtArgs>['model']['EventFolder'];
@@ -11231,10 +12999,12 @@ export namespace Prisma {
       $Result.GetResult<
         Prisma.$EventFolderPayload<ExtArgs>,
         T,
-        'findUnique'
+        'findUnique',
+        ClientOptions
       > | null,
       null,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -11255,10 +13025,12 @@ export namespace Prisma {
       $Result.GetResult<
         Prisma.$EventFolderPayload<ExtArgs>,
         T,
-        'findUniqueOrThrow'
+        'findUniqueOrThrow',
+        ClientOptions
       >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -11280,10 +13052,12 @@ export namespace Prisma {
       $Result.GetResult<
         Prisma.$EventFolderPayload<ExtArgs>,
         T,
-        'findFirst'
+        'findFirst',
+        ClientOptions
       > | null,
       null,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -11306,10 +13080,12 @@ export namespace Prisma {
       $Result.GetResult<
         Prisma.$EventFolderPayload<ExtArgs>,
         T,
-        'findFirstOrThrow'
+        'findFirstOrThrow',
+        ClientOptions
       >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -11331,7 +13107,12 @@ export namespace Prisma {
     findMany<T extends EventFolderFindManyArgs>(
       args?: SelectSubset<T, EventFolderFindManyArgs<ExtArgs>>,
     ): Prisma.PrismaPromise<
-      $Result.GetResult<Prisma.$EventFolderPayload<ExtArgs>, T, 'findMany'>
+      $Result.GetResult<
+        Prisma.$EventFolderPayload<ExtArgs>,
+        T,
+        'findMany',
+        ClientOptions
+      >
     >;
 
     /**
@@ -11349,9 +13130,15 @@ export namespace Prisma {
     create<T extends EventFolderCreateArgs>(
       args: SelectSubset<T, EventFolderCreateArgs<ExtArgs>>,
     ): Prisma__EventFolderClient<
-      $Result.GetResult<Prisma.$EventFolderPayload<ExtArgs>, T, 'create'>,
+      $Result.GetResult<
+        Prisma.$EventFolderPayload<ExtArgs>,
+        T,
+        'create',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -11398,7 +13185,8 @@ export namespace Prisma {
       $Result.GetResult<
         Prisma.$EventFolderPayload<ExtArgs>,
         T,
-        'createManyAndReturn'
+        'createManyAndReturn',
+        ClientOptions
       >
     >;
 
@@ -11417,9 +13205,15 @@ export namespace Prisma {
     delete<T extends EventFolderDeleteArgs>(
       args: SelectSubset<T, EventFolderDeleteArgs<ExtArgs>>,
     ): Prisma__EventFolderClient<
-      $Result.GetResult<Prisma.$EventFolderPayload<ExtArgs>, T, 'delete'>,
+      $Result.GetResult<
+        Prisma.$EventFolderPayload<ExtArgs>,
+        T,
+        'delete',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -11440,9 +13234,15 @@ export namespace Prisma {
     update<T extends EventFolderUpdateArgs>(
       args: SelectSubset<T, EventFolderUpdateArgs<ExtArgs>>,
     ): Prisma__EventFolderClient<
-      $Result.GetResult<Prisma.$EventFolderPayload<ExtArgs>, T, 'update'>,
+      $Result.GetResult<
+        Prisma.$EventFolderPayload<ExtArgs>,
+        T,
+        'update',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -11483,6 +13283,45 @@ export namespace Prisma {
     ): Prisma.PrismaPromise<BatchPayload>;
 
     /**
+     * Update zero or more EventFolders and returns the data updated in the database.
+     * @param {EventFolderUpdateManyAndReturnArgs} args - Arguments to update many EventFolders.
+     * @example
+     * // Update many EventFolders
+     * const eventFolder = await prisma.eventFolder.updateManyAndReturn({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: [
+     *     // ... provide data here
+     *   ]
+     * })
+     *
+     * // Update zero or more EventFolders and only return the `id`
+     * const eventFolderWithIdOnly = await prisma.eventFolder.updateManyAndReturn({
+     *   select: { id: true },
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: [
+     *     // ... provide data here
+     *   ]
+     * })
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     *
+     */
+    updateManyAndReturn<T extends EventFolderUpdateManyAndReturnArgs>(
+      args: SelectSubset<T, EventFolderUpdateManyAndReturnArgs<ExtArgs>>,
+    ): Prisma.PrismaPromise<
+      $Result.GetResult<
+        Prisma.$EventFolderPayload<ExtArgs>,
+        T,
+        'updateManyAndReturn',
+        ClientOptions
+      >
+    >;
+
+    /**
      * Create or update one EventFolder.
      * @param {EventFolderUpsertArgs} args - Arguments to update or create a EventFolder.
      * @example
@@ -11502,9 +13341,15 @@ export namespace Prisma {
     upsert<T extends EventFolderUpsertArgs>(
       args: SelectSubset<T, EventFolderUpsertArgs<ExtArgs>>,
     ): Prisma__EventFolderClient<
-      $Result.GetResult<Prisma.$EventFolderPayload<ExtArgs>, T, 'upsert'>,
+      $Result.GetResult<
+        Prisma.$EventFolderPayload<ExtArgs>,
+        T,
+        'upsert',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -11657,12 +13502,19 @@ export namespace Prisma {
     T,
     Null = never,
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+    ClientOptions = {},
   > extends Prisma.PrismaPromise<T> {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     events<T extends EventFolder$eventsArgs<ExtArgs> = {}>(
       args?: Subset<T, EventFolder$eventsArgs<ExtArgs>>,
     ): Prisma.PrismaPromise<
-      $Result.GetResult<Prisma.$EventPayload<ExtArgs>, T, 'findMany'> | Null
+      | $Result.GetResult<
+          Prisma.$EventPayload<ExtArgs>,
+          T,
+          'findMany',
+          ClientOptions
+        >
+      | Null
     >;
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
@@ -11723,6 +13575,10 @@ export namespace Prisma {
      */
     select?: EventFolderSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the EventFolder
+     */
+    omit?: EventFolderOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: EventFolderInclude<ExtArgs> | null;
@@ -11743,6 +13599,10 @@ export namespace Prisma {
      */
     select?: EventFolderSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the EventFolder
+     */
+    omit?: EventFolderOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: EventFolderInclude<ExtArgs> | null;
@@ -11762,6 +13622,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the EventFolder
      */
     select?: EventFolderSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the EventFolder
+     */
+    omit?: EventFolderOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -11815,6 +13679,10 @@ export namespace Prisma {
      */
     select?: EventFolderSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the EventFolder
+     */
+    omit?: EventFolderOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: EventFolderInclude<ExtArgs> | null;
@@ -11867,6 +13735,10 @@ export namespace Prisma {
      */
     select?: EventFolderSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the EventFolder
+     */
+    omit?: EventFolderOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: EventFolderInclude<ExtArgs> | null;
@@ -11914,6 +13786,10 @@ export namespace Prisma {
      */
     select?: EventFolderSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the EventFolder
+     */
+    omit?: EventFolderOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: EventFolderInclude<ExtArgs> | null;
@@ -11947,6 +13823,10 @@ export namespace Prisma {
      */
     select?: EventFolderSelectCreateManyAndReturn<ExtArgs> | null;
     /**
+     * Omit specific fields from the EventFolder
+     */
+    omit?: EventFolderOmit<ExtArgs> | null;
+    /**
      * The data used to create many EventFolders.
      */
     data: EventFolderCreateManyInput | EventFolderCreateManyInput[];
@@ -11963,6 +13843,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the EventFolder
      */
     select?: EventFolderSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the EventFolder
+     */
+    omit?: EventFolderOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -11994,6 +13878,41 @@ export namespace Prisma {
      * Filter which EventFolders to update
      */
     where?: EventFolderWhereInput;
+    /**
+     * Limit how many EventFolders to update.
+     */
+    limit?: number;
+  };
+
+  /**
+   * EventFolder updateManyAndReturn
+   */
+  export type EventFolderUpdateManyAndReturnArgs<
+    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  > = {
+    /**
+     * Select specific fields to fetch from the EventFolder
+     */
+    select?: EventFolderSelectUpdateManyAndReturn<ExtArgs> | null;
+    /**
+     * Omit specific fields from the EventFolder
+     */
+    omit?: EventFolderOmit<ExtArgs> | null;
+    /**
+     * The data used to update EventFolders.
+     */
+    data: XOR<
+      EventFolderUpdateManyMutationInput,
+      EventFolderUncheckedUpdateManyInput
+    >;
+    /**
+     * Filter which EventFolders to update
+     */
+    where?: EventFolderWhereInput;
+    /**
+     * Limit how many EventFolders to update.
+     */
+    limit?: number;
   };
 
   /**
@@ -12006,6 +13925,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the EventFolder
      */
     select?: EventFolderSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the EventFolder
+     */
+    omit?: EventFolderOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -12035,6 +13958,10 @@ export namespace Prisma {
      */
     select?: EventFolderSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the EventFolder
+     */
+    omit?: EventFolderOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: EventFolderInclude<ExtArgs> | null;
@@ -12054,6 +13981,10 @@ export namespace Prisma {
      * Filter which EventFolders to delete
      */
     where?: EventFolderWhereInput;
+    /**
+     * Limit how many EventFolders to delete.
+     */
+    limit?: number;
   };
 
   /**
@@ -12066,6 +13997,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the Event
      */
     select?: EventSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Event
+     */
+    omit?: EventOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -12088,6 +14023,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the EventFolder
      */
     select?: EventFolderSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the EventFolder
+     */
+    omit?: EventFolderOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -12297,6 +14236,22 @@ export namespace Prisma {
     ExtArgs['result']['message']
   >;
 
+  export type MessageSelectUpdateManyAndReturn<
+    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  > = $Extensions.GetSelect<
+    {
+      id?: boolean;
+      wamId?: boolean;
+      message?: boolean;
+      profilePhoneNumber?: boolean;
+      state?: boolean;
+      created_at?: boolean;
+      updated_at?: boolean;
+      profile?: boolean | ProfileDefaultArgs<ExtArgs>;
+    },
+    ExtArgs['result']['message']
+  >;
+
   export type MessageSelectScalar = {
     id?: boolean;
     wamId?: boolean;
@@ -12307,12 +14262,29 @@ export namespace Prisma {
     updated_at?: boolean;
   };
 
+  export type MessageOmit<
+    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  > = $Extensions.GetOmit<
+    | 'id'
+    | 'wamId'
+    | 'message'
+    | 'profilePhoneNumber'
+    | 'state'
+    | 'created_at'
+    | 'updated_at',
+    ExtArgs['result']['message']
+  >;
   export type MessageInclude<
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
   > = {
     profile?: boolean | ProfileDefaultArgs<ExtArgs>;
   };
   export type MessageIncludeCreateManyAndReturn<
+    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  > = {
+    profile?: boolean | ProfileDefaultArgs<ExtArgs>;
+  };
+  export type MessageIncludeUpdateManyAndReturn<
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
   > = {
     profile?: boolean | ProfileDefaultArgs<ExtArgs>;
@@ -12346,12 +14318,13 @@ export namespace Prisma {
 
   type MessageCountArgs<
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
-  > = Omit<MessageFindManyArgs, 'select' | 'include' | 'distinct'> & {
+  > = Omit<MessageFindManyArgs, 'select' | 'include' | 'distinct' | 'omit'> & {
     select?: MessageCountAggregateInputType | true;
   };
 
   export interface MessageDelegate<
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+    ClientOptions = {},
   > {
     [K: symbol]: {
       types: Prisma.TypeMap<ExtArgs>['model']['Message'];
@@ -12374,10 +14347,12 @@ export namespace Prisma {
       $Result.GetResult<
         Prisma.$MessagePayload<ExtArgs>,
         T,
-        'findUnique'
+        'findUnique',
+        ClientOptions
       > | null,
       null,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -12398,10 +14373,12 @@ export namespace Prisma {
       $Result.GetResult<
         Prisma.$MessagePayload<ExtArgs>,
         T,
-        'findUniqueOrThrow'
+        'findUniqueOrThrow',
+        ClientOptions
       >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -12420,9 +14397,15 @@ export namespace Prisma {
     findFirst<T extends MessageFindFirstArgs>(
       args?: SelectSubset<T, MessageFindFirstArgs<ExtArgs>>,
     ): Prisma__MessageClient<
-      $Result.GetResult<Prisma.$MessagePayload<ExtArgs>, T, 'findFirst'> | null,
+      $Result.GetResult<
+        Prisma.$MessagePayload<ExtArgs>,
+        T,
+        'findFirst',
+        ClientOptions
+      > | null,
       null,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -12442,9 +14425,15 @@ export namespace Prisma {
     findFirstOrThrow<T extends MessageFindFirstOrThrowArgs>(
       args?: SelectSubset<T, MessageFindFirstOrThrowArgs<ExtArgs>>,
     ): Prisma__MessageClient<
-      $Result.GetResult<Prisma.$MessagePayload<ExtArgs>, T, 'findFirstOrThrow'>,
+      $Result.GetResult<
+        Prisma.$MessagePayload<ExtArgs>,
+        T,
+        'findFirstOrThrow',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -12466,7 +14455,12 @@ export namespace Prisma {
     findMany<T extends MessageFindManyArgs>(
       args?: SelectSubset<T, MessageFindManyArgs<ExtArgs>>,
     ): Prisma.PrismaPromise<
-      $Result.GetResult<Prisma.$MessagePayload<ExtArgs>, T, 'findMany'>
+      $Result.GetResult<
+        Prisma.$MessagePayload<ExtArgs>,
+        T,
+        'findMany',
+        ClientOptions
+      >
     >;
 
     /**
@@ -12484,9 +14478,15 @@ export namespace Prisma {
     create<T extends MessageCreateArgs>(
       args: SelectSubset<T, MessageCreateArgs<ExtArgs>>,
     ): Prisma__MessageClient<
-      $Result.GetResult<Prisma.$MessagePayload<ExtArgs>, T, 'create'>,
+      $Result.GetResult<
+        Prisma.$MessagePayload<ExtArgs>,
+        T,
+        'create',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -12533,7 +14533,8 @@ export namespace Prisma {
       $Result.GetResult<
         Prisma.$MessagePayload<ExtArgs>,
         T,
-        'createManyAndReturn'
+        'createManyAndReturn',
+        ClientOptions
       >
     >;
 
@@ -12552,9 +14553,15 @@ export namespace Prisma {
     delete<T extends MessageDeleteArgs>(
       args: SelectSubset<T, MessageDeleteArgs<ExtArgs>>,
     ): Prisma__MessageClient<
-      $Result.GetResult<Prisma.$MessagePayload<ExtArgs>, T, 'delete'>,
+      $Result.GetResult<
+        Prisma.$MessagePayload<ExtArgs>,
+        T,
+        'delete',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -12575,9 +14582,15 @@ export namespace Prisma {
     update<T extends MessageUpdateArgs>(
       args: SelectSubset<T, MessageUpdateArgs<ExtArgs>>,
     ): Prisma__MessageClient<
-      $Result.GetResult<Prisma.$MessagePayload<ExtArgs>, T, 'update'>,
+      $Result.GetResult<
+        Prisma.$MessagePayload<ExtArgs>,
+        T,
+        'update',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -12618,6 +14631,45 @@ export namespace Prisma {
     ): Prisma.PrismaPromise<BatchPayload>;
 
     /**
+     * Update zero or more Messages and returns the data updated in the database.
+     * @param {MessageUpdateManyAndReturnArgs} args - Arguments to update many Messages.
+     * @example
+     * // Update many Messages
+     * const message = await prisma.message.updateManyAndReturn({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: [
+     *     // ... provide data here
+     *   ]
+     * })
+     *
+     * // Update zero or more Messages and only return the `id`
+     * const messageWithIdOnly = await prisma.message.updateManyAndReturn({
+     *   select: { id: true },
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: [
+     *     // ... provide data here
+     *   ]
+     * })
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     *
+     */
+    updateManyAndReturn<T extends MessageUpdateManyAndReturnArgs>(
+      args: SelectSubset<T, MessageUpdateManyAndReturnArgs<ExtArgs>>,
+    ): Prisma.PrismaPromise<
+      $Result.GetResult<
+        Prisma.$MessagePayload<ExtArgs>,
+        T,
+        'updateManyAndReturn',
+        ClientOptions
+      >
+    >;
+
+    /**
      * Create or update one Message.
      * @param {MessageUpsertArgs} args - Arguments to update or create a Message.
      * @example
@@ -12637,9 +14689,15 @@ export namespace Prisma {
     upsert<T extends MessageUpsertArgs>(
       args: SelectSubset<T, MessageUpsertArgs<ExtArgs>>,
     ): Prisma__MessageClient<
-      $Result.GetResult<Prisma.$MessagePayload<ExtArgs>, T, 'upsert'>,
+      $Result.GetResult<
+        Prisma.$MessagePayload<ExtArgs>,
+        T,
+        'upsert',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -12791,6 +14849,7 @@ export namespace Prisma {
     T,
     Null = never,
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+    ClientOptions = {},
   > extends Prisma.PrismaPromise<T> {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     profile<T extends ProfileDefaultArgs<ExtArgs> = {}>(
@@ -12799,11 +14858,13 @@ export namespace Prisma {
       | $Result.GetResult<
           Prisma.$ProfilePayload<ExtArgs>,
           T,
-          'findUniqueOrThrow'
+          'findUniqueOrThrow',
+          ClientOptions
         >
       | Null,
       Null,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
     /**
      * Attaches callbacks for the resolution and/or rejection of the Promise.
@@ -12866,6 +14927,10 @@ export namespace Prisma {
      */
     select?: MessageSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Message
+     */
+    omit?: MessageOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: MessageInclude<ExtArgs> | null;
@@ -12886,6 +14951,10 @@ export namespace Prisma {
      */
     select?: MessageSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Message
+     */
+    omit?: MessageOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: MessageInclude<ExtArgs> | null;
@@ -12905,6 +14974,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the Message
      */
     select?: MessageSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Message
+     */
+    omit?: MessageOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -12958,6 +15031,10 @@ export namespace Prisma {
      */
     select?: MessageSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Message
+     */
+    omit?: MessageOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: MessageInclude<ExtArgs> | null;
@@ -13010,6 +15087,10 @@ export namespace Prisma {
      */
     select?: MessageSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Message
+     */
+    omit?: MessageOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: MessageInclude<ExtArgs> | null;
@@ -13057,6 +15138,10 @@ export namespace Prisma {
      */
     select?: MessageSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Message
+     */
+    omit?: MessageOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: MessageInclude<ExtArgs> | null;
@@ -13090,6 +15175,10 @@ export namespace Prisma {
      */
     select?: MessageSelectCreateManyAndReturn<ExtArgs> | null;
     /**
+     * Omit specific fields from the Message
+     */
+    omit?: MessageOmit<ExtArgs> | null;
+    /**
      * The data used to create many Messages.
      */
     data: MessageCreateManyInput | MessageCreateManyInput[];
@@ -13110,6 +15199,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the Message
      */
     select?: MessageSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Message
+     */
+    omit?: MessageOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -13138,6 +15231,42 @@ export namespace Prisma {
      * Filter which Messages to update
      */
     where?: MessageWhereInput;
+    /**
+     * Limit how many Messages to update.
+     */
+    limit?: number;
+  };
+
+  /**
+   * Message updateManyAndReturn
+   */
+  export type MessageUpdateManyAndReturnArgs<
+    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  > = {
+    /**
+     * Select specific fields to fetch from the Message
+     */
+    select?: MessageSelectUpdateManyAndReturn<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Message
+     */
+    omit?: MessageOmit<ExtArgs> | null;
+    /**
+     * The data used to update Messages.
+     */
+    data: XOR<MessageUpdateManyMutationInput, MessageUncheckedUpdateManyInput>;
+    /**
+     * Filter which Messages to update
+     */
+    where?: MessageWhereInput;
+    /**
+     * Limit how many Messages to update.
+     */
+    limit?: number;
+    /**
+     * Choose, which related nodes to fetch as well
+     */
+    include?: MessageIncludeUpdateManyAndReturn<ExtArgs> | null;
   };
 
   /**
@@ -13150,6 +15279,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the Message
      */
     select?: MessageSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Message
+     */
+    omit?: MessageOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -13179,6 +15312,10 @@ export namespace Prisma {
      */
     select?: MessageSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Message
+     */
+    omit?: MessageOmit<ExtArgs> | null;
+    /**
      * Choose, which related nodes to fetch as well
      */
     include?: MessageInclude<ExtArgs> | null;
@@ -13198,6 +15335,10 @@ export namespace Prisma {
      * Filter which Messages to delete
      */
     where?: MessageWhereInput;
+    /**
+     * Limit how many Messages to delete.
+     */
+    limit?: number;
   };
 
   /**
@@ -13210,6 +15351,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the Message
      */
     select?: MessageSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Message
+     */
+    omit?: MessageOmit<ExtArgs> | null;
     /**
      * Choose, which related nodes to fetch as well
      */
@@ -13406,6 +15551,19 @@ export namespace Prisma {
     ExtArgs['result']['cannedResponse']
   >;
 
+  export type CannedResponseSelectUpdateManyAndReturn<
+    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  > = $Extensions.GetSelect<
+    {
+      id?: boolean;
+      name?: boolean;
+      content?: boolean;
+      created_at?: boolean;
+      updated_at?: boolean;
+    },
+    ExtArgs['result']['cannedResponse']
+  >;
+
   export type CannedResponseSelectScalar = {
     id?: boolean;
     name?: boolean;
@@ -13413,6 +15571,13 @@ export namespace Prisma {
     created_at?: boolean;
     updated_at?: boolean;
   };
+
+  export type CannedResponseOmit<
+    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  > = $Extensions.GetOmit<
+    'id' | 'name' | 'content' | 'created_at' | 'updated_at',
+    ExtArgs['result']['cannedResponse']
+  >;
 
   export type $CannedResponsePayload<
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
@@ -13438,12 +15603,16 @@ export namespace Prisma {
 
   type CannedResponseCountArgs<
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
-  > = Omit<CannedResponseFindManyArgs, 'select' | 'include' | 'distinct'> & {
+  > = Omit<
+    CannedResponseFindManyArgs,
+    'select' | 'include' | 'distinct' | 'omit'
+  > & {
     select?: CannedResponseCountAggregateInputType | true;
   };
 
   export interface CannedResponseDelegate<
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+    ClientOptions = {},
   > {
     [K: symbol]: {
       types: Prisma.TypeMap<ExtArgs>['model']['CannedResponse'];
@@ -13466,10 +15635,12 @@ export namespace Prisma {
       $Result.GetResult<
         Prisma.$CannedResponsePayload<ExtArgs>,
         T,
-        'findUnique'
+        'findUnique',
+        ClientOptions
       > | null,
       null,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -13490,10 +15661,12 @@ export namespace Prisma {
       $Result.GetResult<
         Prisma.$CannedResponsePayload<ExtArgs>,
         T,
-        'findUniqueOrThrow'
+        'findUniqueOrThrow',
+        ClientOptions
       >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -13515,10 +15688,12 @@ export namespace Prisma {
       $Result.GetResult<
         Prisma.$CannedResponsePayload<ExtArgs>,
         T,
-        'findFirst'
+        'findFirst',
+        ClientOptions
       > | null,
       null,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -13541,10 +15716,12 @@ export namespace Prisma {
       $Result.GetResult<
         Prisma.$CannedResponsePayload<ExtArgs>,
         T,
-        'findFirstOrThrow'
+        'findFirstOrThrow',
+        ClientOptions
       >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -13566,7 +15743,12 @@ export namespace Prisma {
     findMany<T extends CannedResponseFindManyArgs>(
       args?: SelectSubset<T, CannedResponseFindManyArgs<ExtArgs>>,
     ): Prisma.PrismaPromise<
-      $Result.GetResult<Prisma.$CannedResponsePayload<ExtArgs>, T, 'findMany'>
+      $Result.GetResult<
+        Prisma.$CannedResponsePayload<ExtArgs>,
+        T,
+        'findMany',
+        ClientOptions
+      >
     >;
 
     /**
@@ -13584,9 +15766,15 @@ export namespace Prisma {
     create<T extends CannedResponseCreateArgs>(
       args: SelectSubset<T, CannedResponseCreateArgs<ExtArgs>>,
     ): Prisma__CannedResponseClient<
-      $Result.GetResult<Prisma.$CannedResponsePayload<ExtArgs>, T, 'create'>,
+      $Result.GetResult<
+        Prisma.$CannedResponsePayload<ExtArgs>,
+        T,
+        'create',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -13633,7 +15821,8 @@ export namespace Prisma {
       $Result.GetResult<
         Prisma.$CannedResponsePayload<ExtArgs>,
         T,
-        'createManyAndReturn'
+        'createManyAndReturn',
+        ClientOptions
       >
     >;
 
@@ -13652,9 +15841,15 @@ export namespace Prisma {
     delete<T extends CannedResponseDeleteArgs>(
       args: SelectSubset<T, CannedResponseDeleteArgs<ExtArgs>>,
     ): Prisma__CannedResponseClient<
-      $Result.GetResult<Prisma.$CannedResponsePayload<ExtArgs>, T, 'delete'>,
+      $Result.GetResult<
+        Prisma.$CannedResponsePayload<ExtArgs>,
+        T,
+        'delete',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -13675,9 +15870,15 @@ export namespace Prisma {
     update<T extends CannedResponseUpdateArgs>(
       args: SelectSubset<T, CannedResponseUpdateArgs<ExtArgs>>,
     ): Prisma__CannedResponseClient<
-      $Result.GetResult<Prisma.$CannedResponsePayload<ExtArgs>, T, 'update'>,
+      $Result.GetResult<
+        Prisma.$CannedResponsePayload<ExtArgs>,
+        T,
+        'update',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -13718,6 +15919,45 @@ export namespace Prisma {
     ): Prisma.PrismaPromise<BatchPayload>;
 
     /**
+     * Update zero or more CannedResponses and returns the data updated in the database.
+     * @param {CannedResponseUpdateManyAndReturnArgs} args - Arguments to update many CannedResponses.
+     * @example
+     * // Update many CannedResponses
+     * const cannedResponse = await prisma.cannedResponse.updateManyAndReturn({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: [
+     *     // ... provide data here
+     *   ]
+     * })
+     *
+     * // Update zero or more CannedResponses and only return the `id`
+     * const cannedResponseWithIdOnly = await prisma.cannedResponse.updateManyAndReturn({
+     *   select: { id: true },
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: [
+     *     // ... provide data here
+     *   ]
+     * })
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     *
+     */
+    updateManyAndReturn<T extends CannedResponseUpdateManyAndReturnArgs>(
+      args: SelectSubset<T, CannedResponseUpdateManyAndReturnArgs<ExtArgs>>,
+    ): Prisma.PrismaPromise<
+      $Result.GetResult<
+        Prisma.$CannedResponsePayload<ExtArgs>,
+        T,
+        'updateManyAndReturn',
+        ClientOptions
+      >
+    >;
+
+    /**
      * Create or update one CannedResponse.
      * @param {CannedResponseUpsertArgs} args - Arguments to update or create a CannedResponse.
      * @example
@@ -13737,9 +15977,15 @@ export namespace Prisma {
     upsert<T extends CannedResponseUpsertArgs>(
       args: SelectSubset<T, CannedResponseUpsertArgs<ExtArgs>>,
     ): Prisma__CannedResponseClient<
-      $Result.GetResult<Prisma.$CannedResponsePayload<ExtArgs>, T, 'upsert'>,
+      $Result.GetResult<
+        Prisma.$CannedResponsePayload<ExtArgs>,
+        T,
+        'upsert',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -13892,6 +16138,7 @@ export namespace Prisma {
     T,
     Null = never,
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+    ClientOptions = {},
   > extends Prisma.PrismaPromise<T> {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     /**
@@ -13953,6 +16200,10 @@ export namespace Prisma {
      */
     select?: CannedResponseSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the CannedResponse
+     */
+    omit?: CannedResponseOmit<ExtArgs> | null;
+    /**
      * Filter, which CannedResponse to fetch.
      */
     where: CannedResponseWhereUniqueInput;
@@ -13969,6 +16220,10 @@ export namespace Prisma {
      */
     select?: CannedResponseSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the CannedResponse
+     */
+    omit?: CannedResponseOmit<ExtArgs> | null;
+    /**
      * Filter, which CannedResponse to fetch.
      */
     where: CannedResponseWhereUniqueInput;
@@ -13984,6 +16239,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the CannedResponse
      */
     select?: CannedResponseSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the CannedResponse
+     */
+    omit?: CannedResponseOmit<ExtArgs> | null;
     /**
      * Filter, which CannedResponse to fetch.
      */
@@ -14033,6 +16292,10 @@ export namespace Prisma {
      */
     select?: CannedResponseSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the CannedResponse
+     */
+    omit?: CannedResponseOmit<ExtArgs> | null;
+    /**
      * Filter, which CannedResponse to fetch.
      */
     where?: CannedResponseWhereInput;
@@ -14081,6 +16344,10 @@ export namespace Prisma {
      */
     select?: CannedResponseSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the CannedResponse
+     */
+    omit?: CannedResponseOmit<ExtArgs> | null;
+    /**
      * Filter, which CannedResponses to fetch.
      */
     where?: CannedResponseWhereInput;
@@ -14124,6 +16391,10 @@ export namespace Prisma {
      */
     select?: CannedResponseSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the CannedResponse
+     */
+    omit?: CannedResponseOmit<ExtArgs> | null;
+    /**
      * The data needed to create a CannedResponse.
      */
     data: XOR<CannedResponseCreateInput, CannedResponseUncheckedCreateInput>;
@@ -14153,6 +16424,10 @@ export namespace Prisma {
      */
     select?: CannedResponseSelectCreateManyAndReturn<ExtArgs> | null;
     /**
+     * Omit specific fields from the CannedResponse
+     */
+    omit?: CannedResponseOmit<ExtArgs> | null;
+    /**
      * The data used to create many CannedResponses.
      */
     data: CannedResponseCreateManyInput | CannedResponseCreateManyInput[];
@@ -14169,6 +16444,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the CannedResponse
      */
     select?: CannedResponseSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the CannedResponse
+     */
+    omit?: CannedResponseOmit<ExtArgs> | null;
     /**
      * The data needed to update a CannedResponse.
      */
@@ -14196,6 +16475,41 @@ export namespace Prisma {
      * Filter which CannedResponses to update
      */
     where?: CannedResponseWhereInput;
+    /**
+     * Limit how many CannedResponses to update.
+     */
+    limit?: number;
+  };
+
+  /**
+   * CannedResponse updateManyAndReturn
+   */
+  export type CannedResponseUpdateManyAndReturnArgs<
+    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  > = {
+    /**
+     * Select specific fields to fetch from the CannedResponse
+     */
+    select?: CannedResponseSelectUpdateManyAndReturn<ExtArgs> | null;
+    /**
+     * Omit specific fields from the CannedResponse
+     */
+    omit?: CannedResponseOmit<ExtArgs> | null;
+    /**
+     * The data used to update CannedResponses.
+     */
+    data: XOR<
+      CannedResponseUpdateManyMutationInput,
+      CannedResponseUncheckedUpdateManyInput
+    >;
+    /**
+     * Filter which CannedResponses to update
+     */
+    where?: CannedResponseWhereInput;
+    /**
+     * Limit how many CannedResponses to update.
+     */
+    limit?: number;
   };
 
   /**
@@ -14208,6 +16522,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the CannedResponse
      */
     select?: CannedResponseSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the CannedResponse
+     */
+    omit?: CannedResponseOmit<ExtArgs> | null;
     /**
      * The filter to search for the CannedResponse to update in case it exists.
      */
@@ -14233,6 +16551,10 @@ export namespace Prisma {
      */
     select?: CannedResponseSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the CannedResponse
+     */
+    omit?: CannedResponseOmit<ExtArgs> | null;
+    /**
      * Filter which CannedResponse to delete.
      */
     where: CannedResponseWhereUniqueInput;
@@ -14248,6 +16570,10 @@ export namespace Prisma {
      * Filter which CannedResponses to delete
      */
     where?: CannedResponseWhereInput;
+    /**
+     * Limit how many CannedResponses to delete.
+     */
+    limit?: number;
   };
 
   /**
@@ -14260,6 +16586,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the CannedResponse
      */
     select?: CannedResponseSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the CannedResponse
+     */
+    omit?: CannedResponseOmit<ExtArgs> | null;
   };
 
   /**
@@ -14429,11 +16759,29 @@ export namespace Prisma {
     ExtArgs['result']['enums']
   >;
 
+  export type EnumsSelectUpdateManyAndReturn<
+    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  > = $Extensions.GetSelect<
+    {
+      id?: boolean;
+      templateStatus?: boolean;
+      templateCategory?: boolean;
+    },
+    ExtArgs['result']['enums']
+  >;
+
   export type EnumsSelectScalar = {
     id?: boolean;
     templateStatus?: boolean;
     templateCategory?: boolean;
   };
+
+  export type EnumsOmit<
+    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  > = $Extensions.GetOmit<
+    'id' | 'templateStatus' | 'templateCategory',
+    ExtArgs['result']['enums']
+  >;
 
   export type $EnumsPayload<
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
@@ -14457,12 +16805,13 @@ export namespace Prisma {
 
   type EnumsCountArgs<
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
-  > = Omit<EnumsFindManyArgs, 'select' | 'include' | 'distinct'> & {
+  > = Omit<EnumsFindManyArgs, 'select' | 'include' | 'distinct' | 'omit'> & {
     select?: EnumsCountAggregateInputType | true;
   };
 
   export interface EnumsDelegate<
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+    ClientOptions = {},
   > {
     [K: symbol]: {
       types: Prisma.TypeMap<ExtArgs>['model']['Enums'];
@@ -14482,9 +16831,15 @@ export namespace Prisma {
     findUnique<T extends EnumsFindUniqueArgs>(
       args: SelectSubset<T, EnumsFindUniqueArgs<ExtArgs>>,
     ): Prisma__EnumsClient<
-      $Result.GetResult<Prisma.$EnumsPayload<ExtArgs>, T, 'findUnique'> | null,
+      $Result.GetResult<
+        Prisma.$EnumsPayload<ExtArgs>,
+        T,
+        'findUnique',
+        ClientOptions
+      > | null,
       null,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -14502,9 +16857,15 @@ export namespace Prisma {
     findUniqueOrThrow<T extends EnumsFindUniqueOrThrowArgs>(
       args: SelectSubset<T, EnumsFindUniqueOrThrowArgs<ExtArgs>>,
     ): Prisma__EnumsClient<
-      $Result.GetResult<Prisma.$EnumsPayload<ExtArgs>, T, 'findUniqueOrThrow'>,
+      $Result.GetResult<
+        Prisma.$EnumsPayload<ExtArgs>,
+        T,
+        'findUniqueOrThrow',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -14523,9 +16884,15 @@ export namespace Prisma {
     findFirst<T extends EnumsFindFirstArgs>(
       args?: SelectSubset<T, EnumsFindFirstArgs<ExtArgs>>,
     ): Prisma__EnumsClient<
-      $Result.GetResult<Prisma.$EnumsPayload<ExtArgs>, T, 'findFirst'> | null,
+      $Result.GetResult<
+        Prisma.$EnumsPayload<ExtArgs>,
+        T,
+        'findFirst',
+        ClientOptions
+      > | null,
       null,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -14545,9 +16912,15 @@ export namespace Prisma {
     findFirstOrThrow<T extends EnumsFindFirstOrThrowArgs>(
       args?: SelectSubset<T, EnumsFindFirstOrThrowArgs<ExtArgs>>,
     ): Prisma__EnumsClient<
-      $Result.GetResult<Prisma.$EnumsPayload<ExtArgs>, T, 'findFirstOrThrow'>,
+      $Result.GetResult<
+        Prisma.$EnumsPayload<ExtArgs>,
+        T,
+        'findFirstOrThrow',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -14569,7 +16942,12 @@ export namespace Prisma {
     findMany<T extends EnumsFindManyArgs>(
       args?: SelectSubset<T, EnumsFindManyArgs<ExtArgs>>,
     ): Prisma.PrismaPromise<
-      $Result.GetResult<Prisma.$EnumsPayload<ExtArgs>, T, 'findMany'>
+      $Result.GetResult<
+        Prisma.$EnumsPayload<ExtArgs>,
+        T,
+        'findMany',
+        ClientOptions
+      >
     >;
 
     /**
@@ -14587,9 +16965,15 @@ export namespace Prisma {
     create<T extends EnumsCreateArgs>(
       args: SelectSubset<T, EnumsCreateArgs<ExtArgs>>,
     ): Prisma__EnumsClient<
-      $Result.GetResult<Prisma.$EnumsPayload<ExtArgs>, T, 'create'>,
+      $Result.GetResult<
+        Prisma.$EnumsPayload<ExtArgs>,
+        T,
+        'create',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -14633,7 +17017,12 @@ export namespace Prisma {
     createManyAndReturn<T extends EnumsCreateManyAndReturnArgs>(
       args?: SelectSubset<T, EnumsCreateManyAndReturnArgs<ExtArgs>>,
     ): Prisma.PrismaPromise<
-      $Result.GetResult<Prisma.$EnumsPayload<ExtArgs>, T, 'createManyAndReturn'>
+      $Result.GetResult<
+        Prisma.$EnumsPayload<ExtArgs>,
+        T,
+        'createManyAndReturn',
+        ClientOptions
+      >
     >;
 
     /**
@@ -14651,9 +17040,15 @@ export namespace Prisma {
     delete<T extends EnumsDeleteArgs>(
       args: SelectSubset<T, EnumsDeleteArgs<ExtArgs>>,
     ): Prisma__EnumsClient<
-      $Result.GetResult<Prisma.$EnumsPayload<ExtArgs>, T, 'delete'>,
+      $Result.GetResult<
+        Prisma.$EnumsPayload<ExtArgs>,
+        T,
+        'delete',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -14674,9 +17069,15 @@ export namespace Prisma {
     update<T extends EnumsUpdateArgs>(
       args: SelectSubset<T, EnumsUpdateArgs<ExtArgs>>,
     ): Prisma__EnumsClient<
-      $Result.GetResult<Prisma.$EnumsPayload<ExtArgs>, T, 'update'>,
+      $Result.GetResult<
+        Prisma.$EnumsPayload<ExtArgs>,
+        T,
+        'update',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -14717,6 +17118,45 @@ export namespace Prisma {
     ): Prisma.PrismaPromise<BatchPayload>;
 
     /**
+     * Update zero or more Enums and returns the data updated in the database.
+     * @param {EnumsUpdateManyAndReturnArgs} args - Arguments to update many Enums.
+     * @example
+     * // Update many Enums
+     * const enums = await prisma.enums.updateManyAndReturn({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: [
+     *     // ... provide data here
+     *   ]
+     * })
+     *
+     * // Update zero or more Enums and only return the `id`
+     * const enumsWithIdOnly = await prisma.enums.updateManyAndReturn({
+     *   select: { id: true },
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: [
+     *     // ... provide data here
+     *   ]
+     * })
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     *
+     */
+    updateManyAndReturn<T extends EnumsUpdateManyAndReturnArgs>(
+      args: SelectSubset<T, EnumsUpdateManyAndReturnArgs<ExtArgs>>,
+    ): Prisma.PrismaPromise<
+      $Result.GetResult<
+        Prisma.$EnumsPayload<ExtArgs>,
+        T,
+        'updateManyAndReturn',
+        ClientOptions
+      >
+    >;
+
+    /**
      * Create or update one Enums.
      * @param {EnumsUpsertArgs} args - Arguments to update or create a Enums.
      * @example
@@ -14736,9 +17176,15 @@ export namespace Prisma {
     upsert<T extends EnumsUpsertArgs>(
       args: SelectSubset<T, EnumsUpsertArgs<ExtArgs>>,
     ): Prisma__EnumsClient<
-      $Result.GetResult<Prisma.$EnumsPayload<ExtArgs>, T, 'upsert'>,
+      $Result.GetResult<
+        Prisma.$EnumsPayload<ExtArgs>,
+        T,
+        'upsert',
+        ClientOptions
+      >,
       never,
-      ExtArgs
+      ExtArgs,
+      ClientOptions
     >;
 
     /**
@@ -14890,6 +17336,7 @@ export namespace Prisma {
     T,
     Null = never,
     ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+    ClientOptions = {},
   > extends Prisma.PrismaPromise<T> {
     readonly [Symbol.toStringTag]: 'PrismaPromise';
     /**
@@ -14949,6 +17396,10 @@ export namespace Prisma {
      */
     select?: EnumsSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Enums
+     */
+    omit?: EnumsOmit<ExtArgs> | null;
+    /**
      * Filter, which Enums to fetch.
      */
     where: EnumsWhereUniqueInput;
@@ -14965,6 +17416,10 @@ export namespace Prisma {
      */
     select?: EnumsSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Enums
+     */
+    omit?: EnumsOmit<ExtArgs> | null;
+    /**
      * Filter, which Enums to fetch.
      */
     where: EnumsWhereUniqueInput;
@@ -14980,6 +17435,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the Enums
      */
     select?: EnumsSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Enums
+     */
+    omit?: EnumsOmit<ExtArgs> | null;
     /**
      * Filter, which Enums to fetch.
      */
@@ -15027,6 +17486,10 @@ export namespace Prisma {
      */
     select?: EnumsSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Enums
+     */
+    omit?: EnumsOmit<ExtArgs> | null;
+    /**
      * Filter, which Enums to fetch.
      */
     where?: EnumsWhereInput;
@@ -15073,6 +17536,10 @@ export namespace Prisma {
      */
     select?: EnumsSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Enums
+     */
+    omit?: EnumsOmit<ExtArgs> | null;
+    /**
      * Filter, which Enums to fetch.
      */
     where?: EnumsWhereInput;
@@ -15114,6 +17581,10 @@ export namespace Prisma {
      */
     select?: EnumsSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Enums
+     */
+    omit?: EnumsOmit<ExtArgs> | null;
+    /**
      * The data needed to create a Enums.
      */
     data: XOR<EnumsCreateInput, EnumsUncheckedCreateInput>;
@@ -15143,6 +17614,10 @@ export namespace Prisma {
      */
     select?: EnumsSelectCreateManyAndReturn<ExtArgs> | null;
     /**
+     * Omit specific fields from the Enums
+     */
+    omit?: EnumsOmit<ExtArgs> | null;
+    /**
      * The data used to create many Enums.
      */
     data: EnumsCreateManyInput | EnumsCreateManyInput[];
@@ -15159,6 +17634,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the Enums
      */
     select?: EnumsSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Enums
+     */
+    omit?: EnumsOmit<ExtArgs> | null;
     /**
      * The data needed to update a Enums.
      */
@@ -15183,6 +17662,38 @@ export namespace Prisma {
      * Filter which Enums to update
      */
     where?: EnumsWhereInput;
+    /**
+     * Limit how many Enums to update.
+     */
+    limit?: number;
+  };
+
+  /**
+   * Enums updateManyAndReturn
+   */
+  export type EnumsUpdateManyAndReturnArgs<
+    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
+  > = {
+    /**
+     * Select specific fields to fetch from the Enums
+     */
+    select?: EnumsSelectUpdateManyAndReturn<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Enums
+     */
+    omit?: EnumsOmit<ExtArgs> | null;
+    /**
+     * The data used to update Enums.
+     */
+    data: XOR<EnumsUpdateManyMutationInput, EnumsUncheckedUpdateManyInput>;
+    /**
+     * Filter which Enums to update
+     */
+    where?: EnumsWhereInput;
+    /**
+     * Limit how many Enums to update.
+     */
+    limit?: number;
   };
 
   /**
@@ -15195,6 +17706,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the Enums
      */
     select?: EnumsSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Enums
+     */
+    omit?: EnumsOmit<ExtArgs> | null;
     /**
      * The filter to search for the Enums to update in case it exists.
      */
@@ -15220,6 +17735,10 @@ export namespace Prisma {
      */
     select?: EnumsSelect<ExtArgs> | null;
     /**
+     * Omit specific fields from the Enums
+     */
+    omit?: EnumsOmit<ExtArgs> | null;
+    /**
      * Filter which Enums to delete.
      */
     where: EnumsWhereUniqueInput;
@@ -15235,6 +17754,10 @@ export namespace Prisma {
      * Filter which Enums to delete
      */
     where?: EnumsWhereInput;
+    /**
+     * Limit how many Enums to delete.
+     */
+    limit?: number;
   };
 
   /**
@@ -15247,6 +17770,10 @@ export namespace Prisma {
      * Select specific fields to fetch from the Enums
      */
     select?: EnumsSelect<ExtArgs> | null;
+    /**
+     * Omit specific fields from the Enums
+     */
+    omit?: EnumsOmit<ExtArgs> | null;
   };
 
   /**
@@ -15726,11 +18253,11 @@ export namespace Prisma {
     messages?: MessageListRelationFilter;
     tags?: TagListRelationFilter;
     birthLocation?: XOR<
-      LocationNullableRelationFilter,
+      LocationNullableScalarRelationFilter,
       LocationWhereInput
     > | null;
     residenceLocation?: XOR<
-      LocationNullableRelationFilter,
+      LocationNullableScalarRelationFilter,
       LocationWhereInput
     > | null;
   };
@@ -15794,11 +18321,11 @@ export namespace Prisma {
       messages?: MessageListRelationFilter;
       tags?: TagListRelationFilter;
       birthLocation?: XOR<
-        LocationNullableRelationFilter,
+        LocationNullableScalarRelationFilter,
         LocationWhereInput
       > | null;
       residenceLocation?: XOR<
-        LocationNullableRelationFilter,
+        LocationNullableScalarRelationFilter,
         LocationWhereInput
       > | null;
     },
@@ -15978,9 +18505,12 @@ export namespace Prisma {
     solvedById?: StringNullableFilter<'Comment'> | string | null;
     created_at?: DateTimeFilter<'Comment'> | Date | string;
     updated_at?: DateTimeFilter<'Comment'> | Date | string;
-    account?: XOR<AccountRelationFilter, AccountWhereInput>;
-    profile?: XOR<ProfileRelationFilter, ProfileWhereInput>;
-    solvedBy?: XOR<AccountNullableRelationFilter, AccountWhereInput> | null;
+    account?: XOR<AccountScalarRelationFilter, AccountWhereInput>;
+    profile?: XOR<ProfileScalarRelationFilter, ProfileWhereInput>;
+    solvedBy?: XOR<
+      AccountNullableScalarRelationFilter,
+      AccountWhereInput
+    > | null;
   };
 
   export type CommentOrderByWithRelationInput = {
@@ -16014,9 +18544,12 @@ export namespace Prisma {
       solvedById?: StringNullableFilter<'Comment'> | string | null;
       created_at?: DateTimeFilter<'Comment'> | Date | string;
       updated_at?: DateTimeFilter<'Comment'> | Date | string;
-      account?: XOR<AccountRelationFilter, AccountWhereInput>;
-      profile?: XOR<ProfileRelationFilter, ProfileWhereInput>;
-      solvedBy?: XOR<AccountNullableRelationFilter, AccountWhereInput> | null;
+      account?: XOR<AccountScalarRelationFilter, AccountWhereInput>;
+      profile?: XOR<ProfileScalarRelationFilter, ProfileWhereInput>;
+      solvedBy?: XOR<
+        AccountNullableScalarRelationFilter,
+        AccountWhereInput
+      > | null;
     },
     'id'
   >;
@@ -16071,9 +18604,15 @@ export namespace Prisma {
     groupId?: StringFilter<'Tag'> | string;
     created_at?: DateTimeFilter<'Tag'> | Date | string;
     updated_at?: DateTimeFilter<'Tag'> | Date | string;
-    group?: XOR<TagGroupRelationFilter, TagGroupWhereInput>;
-    assistedEvent?: XOR<EventNullableRelationFilter, EventWhereInput> | null;
-    confirmedEvent?: XOR<EventNullableRelationFilter, EventWhereInput> | null;
+    group?: XOR<TagGroupScalarRelationFilter, TagGroupWhereInput>;
+    assistedEvent?: XOR<
+      EventNullableScalarRelationFilter,
+      EventWhereInput
+    > | null;
+    confirmedEvent?: XOR<
+      EventNullableScalarRelationFilter,
+      EventWhereInput
+    > | null;
     accounts?: AccountListRelationFilter;
     profiles?: ProfileListRelationFilter;
     accountsGlobalFilter?: AccountListRelationFilter;
@@ -16105,9 +18644,15 @@ export namespace Prisma {
       groupId?: StringFilter<'Tag'> | string;
       created_at?: DateTimeFilter<'Tag'> | Date | string;
       updated_at?: DateTimeFilter<'Tag'> | Date | string;
-      group?: XOR<TagGroupRelationFilter, TagGroupWhereInput>;
-      assistedEvent?: XOR<EventNullableRelationFilter, EventWhereInput> | null;
-      confirmedEvent?: XOR<EventNullableRelationFilter, EventWhereInput> | null;
+      group?: XOR<TagGroupScalarRelationFilter, TagGroupWhereInput>;
+      assistedEvent?: XOR<
+        EventNullableScalarRelationFilter,
+        EventWhereInput
+      > | null;
+      confirmedEvent?: XOR<
+        EventNullableScalarRelationFilter,
+        EventWhereInput
+      > | null;
       accounts?: AccountListRelationFilter;
       profiles?: ProfileListRelationFilter;
       accountsGlobalFilter?: AccountListRelationFilter;
@@ -16225,12 +18770,12 @@ export namespace Prisma {
     created_at?: DateTimeFilter<'Event'> | Date | string;
     updated_at?: DateTimeFilter<'Event'> | Date | string;
     folder?: XOR<
-      EventFolderNullableRelationFilter,
+      EventFolderNullableScalarRelationFilter,
       EventFolderWhereInput
     > | null;
-    tagAssisted?: XOR<TagRelationFilter, TagWhereInput>;
-    tagConfirmed?: XOR<TagRelationFilter, TagWhereInput>;
-    supraEvent?: XOR<EventNullableRelationFilter, EventWhereInput> | null;
+    tagAssisted?: XOR<TagScalarRelationFilter, TagWhereInput>;
+    tagConfirmed?: XOR<TagScalarRelationFilter, TagWhereInput>;
+    supraEvent?: XOR<EventNullableScalarRelationFilter, EventWhereInput> | null;
     subEvents?: EventListRelationFilter;
   };
 
@@ -16268,12 +18813,15 @@ export namespace Prisma {
       created_at?: DateTimeFilter<'Event'> | Date | string;
       updated_at?: DateTimeFilter<'Event'> | Date | string;
       folder?: XOR<
-        EventFolderNullableRelationFilter,
+        EventFolderNullableScalarRelationFilter,
         EventFolderWhereInput
       > | null;
-      tagAssisted?: XOR<TagRelationFilter, TagWhereInput>;
-      tagConfirmed?: XOR<TagRelationFilter, TagWhereInput>;
-      supraEvent?: XOR<EventNullableRelationFilter, EventWhereInput> | null;
+      tagAssisted?: XOR<TagScalarRelationFilter, TagWhereInput>;
+      tagConfirmed?: XOR<TagScalarRelationFilter, TagWhereInput>;
+      supraEvent?: XOR<
+        EventNullableScalarRelationFilter,
+        EventWhereInput
+      > | null;
       subEvents?: EventListRelationFilter;
     },
     'id' | 'tagAssistedId' | 'tagConfirmedId'
@@ -16388,7 +18936,7 @@ export namespace Prisma {
     state?: EnumMessageStateFilter<'Message'> | $Enums.MessageState;
     created_at?: DateTimeFilter<'Message'> | Date | string;
     updated_at?: DateTimeFilter<'Message'> | Date | string;
-    profile?: XOR<ProfileRelationFilter, ProfileWhereInput>;
+    profile?: XOR<ProfileScalarRelationFilter, ProfileWhereInput>;
   };
 
   export type MessageOrderByWithRelationInput = {
@@ -16414,7 +18962,7 @@ export namespace Prisma {
       state?: EnumMessageStateFilter<'Message'> | $Enums.MessageState;
       created_at?: DateTimeFilter<'Message'> | Date | string;
       updated_at?: DateTimeFilter<'Message'> | Date | string;
-      profile?: XOR<ProfileRelationFilter, ProfileWhereInput>;
+      profile?: XOR<ProfileScalarRelationFilter, ProfileWhereInput>;
     },
     'id' | 'wamId'
   >;
@@ -17750,7 +20298,7 @@ export namespace Prisma {
     none?: MessageWhereInput;
   };
 
-  export type LocationNullableRelationFilter = {
+  export type LocationNullableScalarRelationFilter = {
     is?: LocationWhereInput | null;
     isNot?: LocationWhereInput | null;
   };
@@ -17976,17 +20524,17 @@ export namespace Prisma {
     _max?: NestedFloatFilter<$PrismaModel>;
   };
 
-  export type AccountRelationFilter = {
+  export type AccountScalarRelationFilter = {
     is?: AccountWhereInput;
     isNot?: AccountWhereInput;
   };
 
-  export type ProfileRelationFilter = {
+  export type ProfileScalarRelationFilter = {
     is?: ProfileWhereInput;
     isNot?: ProfileWhereInput;
   };
 
-  export type AccountNullableRelationFilter = {
+  export type AccountNullableScalarRelationFilter = {
     is?: AccountWhereInput | null;
     isNot?: AccountWhereInput | null;
   };
@@ -18037,12 +20585,12 @@ export namespace Prisma {
     not?: NestedEnumTagTypeFilter<$PrismaModel> | $Enums.TagType;
   };
 
-  export type TagGroupRelationFilter = {
+  export type TagGroupScalarRelationFilter = {
     is?: TagGroupWhereInput;
     isNot?: TagGroupWhereInput;
   };
 
-  export type EventNullableRelationFilter = {
+  export type EventNullableScalarRelationFilter = {
     is?: EventWhereInput | null;
     isNot?: EventWhereInput | null;
   };
@@ -18121,12 +20669,12 @@ export namespace Prisma {
     updated_at?: SortOrder;
   };
 
-  export type EventFolderNullableRelationFilter = {
+  export type EventFolderNullableScalarRelationFilter = {
     is?: EventFolderWhereInput | null;
     isNot?: EventFolderWhereInput | null;
   };
 
-  export type TagRelationFilter = {
+  export type TagScalarRelationFilter = {
     is?: TagWhereInput;
     isNot?: TagWhereInput;
   };
@@ -18222,9 +20770,9 @@ export namespace Prisma {
     string_contains?: string | StringFieldRefInput<$PrismaModel>;
     string_starts_with?: string | StringFieldRefInput<$PrismaModel>;
     string_ends_with?: string | StringFieldRefInput<$PrismaModel>;
-    array_contains?: InputJsonValue | JsonFieldRefInput<$PrismaModel> | null;
     array_starts_with?: InputJsonValue | JsonFieldRefInput<$PrismaModel> | null;
     array_ends_with?: InputJsonValue | JsonFieldRefInput<$PrismaModel> | null;
+    array_contains?: InputJsonValue | JsonFieldRefInput<$PrismaModel> | null;
     lt?: InputJsonValue | JsonFieldRefInput<$PrismaModel>;
     lte?: InputJsonValue | JsonFieldRefInput<$PrismaModel>;
     gt?: InputJsonValue | JsonFieldRefInput<$PrismaModel>;
@@ -18297,9 +20845,9 @@ export namespace Prisma {
     string_contains?: string | StringFieldRefInput<$PrismaModel>;
     string_starts_with?: string | StringFieldRefInput<$PrismaModel>;
     string_ends_with?: string | StringFieldRefInput<$PrismaModel>;
-    array_contains?: InputJsonValue | JsonFieldRefInput<$PrismaModel> | null;
     array_starts_with?: InputJsonValue | JsonFieldRefInput<$PrismaModel> | null;
     array_ends_with?: InputJsonValue | JsonFieldRefInput<$PrismaModel> | null;
+    array_contains?: InputJsonValue | JsonFieldRefInput<$PrismaModel> | null;
     lt?: InputJsonValue | JsonFieldRefInput<$PrismaModel>;
     lte?: InputJsonValue | JsonFieldRefInput<$PrismaModel>;
     gt?: InputJsonValue | JsonFieldRefInput<$PrismaModel>;
@@ -20436,9 +22984,9 @@ export namespace Prisma {
     string_contains?: string | StringFieldRefInput<$PrismaModel>;
     string_starts_with?: string | StringFieldRefInput<$PrismaModel>;
     string_ends_with?: string | StringFieldRefInput<$PrismaModel>;
-    array_contains?: InputJsonValue | JsonFieldRefInput<$PrismaModel> | null;
     array_starts_with?: InputJsonValue | JsonFieldRefInput<$PrismaModel> | null;
     array_ends_with?: InputJsonValue | JsonFieldRefInput<$PrismaModel> | null;
+    array_contains?: InputJsonValue | JsonFieldRefInput<$PrismaModel> | null;
     lt?: InputJsonValue | JsonFieldRefInput<$PrismaModel>;
     lte?: InputJsonValue | JsonFieldRefInput<$PrismaModel>;
     gt?: InputJsonValue | JsonFieldRefInput<$PrismaModel>;
@@ -23746,118 +26294,6 @@ export namespace Prisma {
     created_at?: DateTimeFieldUpdateOperationsInput | Date | string;
     updated_at?: DateTimeFieldUpdateOperationsInput | Date | string;
   };
-
-  /**
-   * Aliases for legacy arg types
-   */
-  /**
-   * @deprecated Use AccountCountOutputTypeDefaultArgs instead
-   */
-  export type AccountCountOutputTypeArgs<
-    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
-  > = AccountCountOutputTypeDefaultArgs<ExtArgs>;
-  /**
-   * @deprecated Use ProfileCountOutputTypeDefaultArgs instead
-   */
-  export type ProfileCountOutputTypeArgs<
-    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
-  > = ProfileCountOutputTypeDefaultArgs<ExtArgs>;
-  /**
-   * @deprecated Use LocationCountOutputTypeDefaultArgs instead
-   */
-  export type LocationCountOutputTypeArgs<
-    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
-  > = LocationCountOutputTypeDefaultArgs<ExtArgs>;
-  /**
-   * @deprecated Use TagCountOutputTypeDefaultArgs instead
-   */
-  export type TagCountOutputTypeArgs<
-    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
-  > = TagCountOutputTypeDefaultArgs<ExtArgs>;
-  /**
-   * @deprecated Use TagGroupCountOutputTypeDefaultArgs instead
-   */
-  export type TagGroupCountOutputTypeArgs<
-    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
-  > = TagGroupCountOutputTypeDefaultArgs<ExtArgs>;
-  /**
-   * @deprecated Use EventCountOutputTypeDefaultArgs instead
-   */
-  export type EventCountOutputTypeArgs<
-    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
-  > = EventCountOutputTypeDefaultArgs<ExtArgs>;
-  /**
-   * @deprecated Use EventFolderCountOutputTypeDefaultArgs instead
-   */
-  export type EventFolderCountOutputTypeArgs<
-    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
-  > = EventFolderCountOutputTypeDefaultArgs<ExtArgs>;
-  /**
-   * @deprecated Use AccountDefaultArgs instead
-   */
-  export type AccountArgs<
-    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
-  > = AccountDefaultArgs<ExtArgs>;
-  /**
-   * @deprecated Use ProfileDefaultArgs instead
-   */
-  export type ProfileArgs<
-    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
-  > = ProfileDefaultArgs<ExtArgs>;
-  /**
-   * @deprecated Use LocationDefaultArgs instead
-   */
-  export type LocationArgs<
-    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
-  > = LocationDefaultArgs<ExtArgs>;
-  /**
-   * @deprecated Use CommentDefaultArgs instead
-   */
-  export type CommentArgs<
-    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
-  > = CommentDefaultArgs<ExtArgs>;
-  /**
-   * @deprecated Use TagDefaultArgs instead
-   */
-  export type TagArgs<
-    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
-  > = TagDefaultArgs<ExtArgs>;
-  /**
-   * @deprecated Use TagGroupDefaultArgs instead
-   */
-  export type TagGroupArgs<
-    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
-  > = TagGroupDefaultArgs<ExtArgs>;
-  /**
-   * @deprecated Use EventDefaultArgs instead
-   */
-  export type EventArgs<
-    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
-  > = EventDefaultArgs<ExtArgs>;
-  /**
-   * @deprecated Use EventFolderDefaultArgs instead
-   */
-  export type EventFolderArgs<
-    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
-  > = EventFolderDefaultArgs<ExtArgs>;
-  /**
-   * @deprecated Use MessageDefaultArgs instead
-   */
-  export type MessageArgs<
-    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
-  > = MessageDefaultArgs<ExtArgs>;
-  /**
-   * @deprecated Use CannedResponseDefaultArgs instead
-   */
-  export type CannedResponseArgs<
-    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
-  > = CannedResponseDefaultArgs<ExtArgs>;
-  /**
-   * @deprecated Use EnumsDefaultArgs instead
-   */
-  export type EnumsArgs<
-    ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs,
-  > = EnumsDefaultArgs<ExtArgs>;
 
   /**
    * Batch Payload for updateMany & deleteMany & createMany


### PR DESCRIPTION
En este PR se termina la integración del router de la sección de `CSV`. Para eso se hizo lo siguiente:

- Exportar los DTO's para usarlos en EM
- Cambiar las rutas del router de `CSV` de GET a POST
- Modificaciones en la ruta de `download-all-tables` para su correcto funcionamiento