### PR TITLE
Expo 341 expo backend borrado de ticket groups no comprados

### DIFF
--- a/src/event/event.controller.ts
+++ b/src/event/event.controller.ts
@@ -37,6 +37,7 @@ import { setHoursAndMinutes } from '@/shared/utils/utils';
 import { ExistingRecord } from '@/shared/validation/checkExistingRecord';
 import { TagGroupService } from '@/tag-group/tag-group.service';
 import { TagService } from '@/tag/tag.service';
+import { TicketGroupService } from '@/ticket-group/ticket-group.service';
 import {
   Body,
   ConflictException,
@@ -69,6 +70,7 @@ export class EventController {
     private readonly tagGroupService: TagGroupService,
     private readonly tagService: TagService,
     private readonly eventTicketsService: EventTicketService,
+    private readonly ticketGroupService: TicketGroupService,
   ) {}
 
   @ApiCreatedResponse({
@@ -205,6 +207,7 @@ export class EventController {
   async findById(
     @Param('id', new ExistingRecord('event')) id: string,
   ): Promise<z.infer<typeof getByIdEventResponseSchema>> {
+    await this.ticketGroupService.deleteBookedTicketsGroup(id);
     return await this.eventService.findById(id);
   }
 

--- a/src/event/event.module.ts
+++ b/src/event/event.module.ts
@@ -4,11 +4,11 @@ import { EventTicketService } from '@/event-ticket/event-ticket.service';
 import { ProfileService } from '@/profile/profile.service';
 import { TagGroupService } from '@/tag-group/tag-group.service';
 import { TagService } from '@/tag/tag.service';
+import { TicketGroupService } from '@/ticket-group/ticket-group.service';
 import { Module } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { EventController } from './event.controller';
 import { EventService } from './event.service';
-
 @Module({
   providers: [
     EventService,
@@ -19,6 +19,7 @@ import { EventService } from './event.service';
     TagService,
     EventTicketService,
     ProfileService,
+    TicketGroupService,
   ],
   controllers: [EventController],
 })

--- a/src/ticket-group/ticket-group.controller.ts
+++ b/src/ticket-group/ticket-group.controller.ts
@@ -123,6 +123,7 @@ export class TicketGroupController {
   async findTicketsByEvent(
     @Param('id', new ExistingRecord('event')) id: string,
   ): Promise<z.infer<typeof findTicketsByEventResponseSchema>> {
+    await this.ticketGroupService.deleteBookedTicketsGroup(id);
     const ticketsEmitted =
       (await this.ticketGroupService.findTicketsByEvent(id))._sum
         .amountTickets ?? 0;

--- a/src/ticket-group/ticket-group.controller.ts
+++ b/src/ticket-group/ticket-group.controller.ts
@@ -93,10 +93,11 @@ export class TicketGroupController {
       );
     }
     const ticketsEmitted =
-      await this.ticketService.findEmittedAmountByEventAndType(
-        createTicketGroupDto.eventId,
-        TicketType.SPECTATOR,
-      );
+      (
+        await this.ticketGroupService.findTicketsByEvent(
+          createTicketGroupDto.eventId,
+        )
+      )._sum.amountTickets ?? 0;
     if (
       ticketsEmitted + createTicketGroupDto.amountTickets >
       maxTicketsToEmit

--- a/src/ticket-group/ticket-group.controller.ts
+++ b/src/ticket-group/ticket-group.controller.ts
@@ -123,10 +123,8 @@ export class TicketGroupController {
     @Param('id', new ExistingRecord('event')) id: string,
   ): Promise<z.infer<typeof findTicketsByEventResponseSchema>> {
     const ticketsEmitted =
-      await this.ticketService.findEmittedAmountByEventAndType(
-        id,
-        TicketType.SPECTATOR,
-      );
+      (await this.ticketGroupService.findTicketsByEvent(id))._sum
+        .amountTickets ?? 0;
 
     return { tickets: ticketsEmitted };
   }

--- a/src/ticket-group/ticket-group.service.ts
+++ b/src/ticket-group/ticket-group.service.ts
@@ -47,7 +47,9 @@ export class TicketGroupService {
     return group;
   }
 
-  async findTicketsByEvent(eventId: string) {
+  async findTicketsByEvent(
+    eventId: string,
+  ): Promise<{ _sum: { amountTickets: number | null } }> {
     return await this.prisma.ticketGroup.aggregate({
       where: { eventId },
       _sum: {
@@ -82,8 +84,8 @@ export class TicketGroupService {
     });
   }
 
-  async deleteBookedTicketsGroup(eventId: string) {
-    return await this.prisma.ticketGroup.deleteMany({
+  async deleteBookedTicketsGroup(eventId: string): Promise<void> {
+    await this.prisma.ticketGroup.deleteMany({
       where: {
         status: TicketGroupStatus.BOOKED,
         eventId,

--- a/src/ticket-group/ticket-group.service.ts
+++ b/src/ticket-group/ticket-group.service.ts
@@ -72,4 +72,16 @@ export class TicketGroupService {
       },
     });
   }
+
+  async deleteBookedTicketsGroup(eventId: string) {
+    return await this.prisma.ticketGroup.deleteMany({
+      where: {
+        status: TicketGroupStatus.BOOKED,
+        eventId,
+        created_at: {
+          lt: new Date(Date.now() - 1000 * 60 * 10),
+        },
+      },
+    });
+  }
 }

--- a/src/ticket-group/ticket-group.service.ts
+++ b/src/ticket-group/ticket-group.service.ts
@@ -79,7 +79,7 @@ export class TicketGroupService {
         status: TicketGroupStatus.BOOKED,
         eventId,
         created_at: {
-          lt: new Date(Date.now() - 1000 * 60 * 10),
+          gt: new Date(Date.now() - 1000 * 60 * 10),
         },
       },
     });

--- a/src/ticket-group/ticket-group.service.ts
+++ b/src/ticket-group/ticket-group.service.ts
@@ -88,7 +88,7 @@ export class TicketGroupService {
         status: TicketGroupStatus.BOOKED,
         eventId,
         created_at: {
-          gt: new Date(Date.now() - 1000 * 60 * 10),
+          lt: new Date(Date.now() - 1000 * 60 * 10),
         },
       },
     });

--- a/src/ticket-group/ticket-group.service.ts
+++ b/src/ticket-group/ticket-group.service.ts
@@ -47,6 +47,15 @@ export class TicketGroupService {
     return group;
   }
 
+  async findTicketsByEvent(eventId: string) {
+    return await this.prisma.ticketGroup.aggregate({
+      where: { eventId },
+      _sum: {
+        amountTickets: true,
+      },
+    });
+  }
+
   async update(
     id: string,
     updateTicketGroupDto: UpdateTicketGroupDto,


### PR DESCRIPTION
En este PR se implementa la funcionalidad de eliminar todos los Ticket Groups en estado `BOOKED` asociados a cierto evento que hayan pasado más de 10 minutos desde su creación. De esta forma, si alguien empezó con el proceso de compra de un Ticket, se queda a la mitad y no lo retoma, se pueden utilizar por otro usuario.